### PR TITLE
Run the CI integration tests upon pull request only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,5 @@
 name: Tests
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           provider: microk8s
       - name: Run integration tests
-        run: tox -e integration-databsae
+        run: tox -e integration-database
 
   release-to-charmhub:
     name: Release to CharmHub


### PR DESCRIPTION
## Issue
We run the integration tests upon push to `main` through the `release` workflows. We duplicate these tests by running the `ci` workflows as well.

## Solution
Disable running tests upon push to `main`.

## Release Notes
Run the CI integration tests upon pull request only
