### PR TITLE
Add CI workflow dependency + import integration test CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
-name: Tests
+name: integration and other tests
+
 on:
+  workflow_call:
   pull_request:
 
 jobs:
@@ -13,6 +15,7 @@ jobs:
         run: python3 -m pip install tox
       - name: Run linters
         run: tox -e lint
+
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -23,8 +26,12 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
+
   integration-test-database-microk8s:
     name: Integration tests for database relations (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,48 +20,16 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run linters
-        run: tox -e lint
-
-  unit-test:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        run: python -m pip install tox
-      - name: Run tests
-        run: tox -e unit
-
-  integration-test-database:
-    name: Integration tests for database relations
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
-      - name: Run integration tests
-        run: tox -e integration-database
+  ci-tests:
+    needs:
+      - lib-check
+    uses: ./.github/workflows/ci.yaml
 
   release-to-charmhub:
     name: Release to CharmHub
     needs:
       - lib-check
-      - lint
-      - unit-test
-      - integration-test-database
+      - ci-tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Issue
1. We are running heavy integration tests even if the lighter ones (like linting and unit tests) 
2. We are repeating CI workflows in ci.yaml and release.yaml

## Solution
1. Introduce dependencies to only run the heavier CI workflows after the lighter ones finish successfully
2. Import CI workflows from ci.yaml into release.yaml

## Release Notes
Add CI workflow dependency + import integration test CI workflows
