### PR TITLE
Bump the charming actions version for releasing the charm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,10 +37,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@1.0.3
+        uses: canonical/charming-actions/channel@2.0.0-rc
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@1.0.3
+        uses: canonical/charming-actions/upload-charm@2.0.0-rc
         with:
           resource-overrides: "mysql-router-image:1"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"


### PR DESCRIPTION
## Issue
We're running into the [following error](https://github.com/canonical/mysql-router-k8s-operator/actions/runs/3206628347/jobs/5241167958#step:4:15) when trying to release the charm to charmhub using CI. We speculate that since the version of the charming actions is old, it is retrieving the tag version as `undefined` and trying to tag the repo with `revundefined` (which already exists).

## Solution
Update the version of the `channel` and `upload-charm` actions to `2.0.0-rc`

## Release Notes
Bump the charming actions version for releasing the charm