### PR TITLE
DPE-904 Fixing Juju SDK warning: SIMULATE_CAN_CONNECT=True

### DIFF
--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import ops.testing
+
+# Since ops>=1.4 this enables better connection tracking.
+# See: More at https://juju.is/docs/sdk/testing#heading--simulate-can-connect
+ops.testing.SIMULATE_CAN_CONNECT = True


### PR DESCRIPTION
## Issue
It is a side effect fix in DPE-904 to address annoying warning.

## Solution
Use SIMULATE_CAN_CONNECT=True as recommended by Juju SDK.

## Context
Just a warning fix, should have no other effect.

## Release Notes
Juju testing SDK: use SIMULATE_CAN_CONNECT=True for better connection tracking.

## Testing
Just a warning fix, should have no other effect.