### PR TITLE
Deploy mysqlrouter charm in integration test without the trust flag since it's not needed

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -53,7 +53,6 @@ async def test_database_relation(ops_test: OpsTest):
             application_name=MYSQL_ROUTER_APP_NAME,
             resources=mysqlrouter_resources,
             num_units=1,
-            trust=True,  # Needed to be able to delete/create k8s services in the charm
         ),
         ops_test.model.deploy(
             application_charm, application_name=APPLICATION_APP_NAME, num_units=1


### PR DESCRIPTION
## Issue
Modifying the integration test for [DPE-904](https://warthogs.atlassian.net/browse/DPE-904)

[PR 10](https://github.com/canonical/mysql-router-k8s-operator/pull/10) refactored the charm to no longer require the `--trust` option when deploying the mysql-router charm. However, we have yet to update the integration test to no longer pass the `--trust` flag when testing the mysql-router charm.

## Solution
Remove the `--trust` flag from the integration test

## Release Notes
Deploy mysqlrouter charm in integration test without the trust flag since it's not needed

[DPE-904]: https://warthogs.atlassian.net/browse/DPE-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ