### PR TITLE
Bootstrap new units as soon as possible instead of doing so in update-status

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -191,7 +191,7 @@ class MySQLRouterOperatorCharm(CharmBase):
 
         requires_data = json.loads(self.app_peer_data[MYSQL_ROUTER_REQUIRES_DATA])
 
-        [endpoint_host, endpoint_port] = requires_data["endpoints"].split(",")[0].split(":")
+        endpoint_host, endpoint_port = requires_data["endpoints"].split(",")[0].split(":")
         pebble_layer = self._mysql_router_layer(
             endpoint_host,
             endpoint_port,
@@ -257,11 +257,9 @@ class MySQLRouterOperatorCharm(CharmBase):
 
         if self.unit.is_leader():
             num_units_bootstrapped = sum(
-                [
-                    1
-                    for unit in self._peers.units.union({self.unit})
-                    if self._peers.data[unit].get(UNIT_BOOTSTRAPPED)
-                ]
+                1
+                for unit in self._peers.units.union({self.unit})
+                if self._peers.data[unit].get(UNIT_BOOTSTRAPPED)
             )
             self.app_peer_data[NUM_UNITS_BOOTSTRAPPED] = str(num_units_bootstrapped)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -41,11 +41,12 @@ class MySQLRouterOperatorCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
+        self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.leader_elected, self._on_leader_elected)
         self.framework.observe(
             self.on.mysql_router_pebble_ready, self._on_mysql_router_pebble_ready
         )
-        self.framework.observe(self.on.update_status, self._on_update_status)
+        self.framework.observe(self.on[PEER].relation_changed, self._on_peer_relation_changed)
 
         self.database_provides = DatabaseProvidesRelation(self)
         self.database_requires = DatabaseRequiresRelation(self)
@@ -90,6 +91,11 @@ class MySQLRouterOperatorCharm(CharmBase):
     # =======================
 
     def _create_service(self, name: str, port: int) -> None:
+        """Create a k8s service that is tied to pod-0.
+
+        The k8s service is tied to pod-0 so that the service is auto cleaned by
+        k8s when the last pod is scaled down.
+        """
         client = Client()
         pod0 = client.get(
             res=Pod,
@@ -184,9 +190,11 @@ class MySQLRouterOperatorCharm(CharmBase):
             return False
 
         requires_data = json.loads(self.app_peer_data[MYSQL_ROUTER_REQUIRES_DATA])
+
+        [endpoint_host, endpoint_port] = requires_data["endpoints"].split(",")[0].split(":")
         pebble_layer = self._mysql_router_layer(
-            requires_data["endpoints"].split(",")[0].split(":")[0],
-            "3306",
+            endpoint_host,
+            endpoint_port,
             requires_data["username"],
             self._get_secret("app", "database-password"),
         )
@@ -202,10 +210,6 @@ class MySQLRouterOperatorCharm(CharmBase):
 
             self.unit_peer_data[UNIT_BOOTSTRAPPED] = "true"
 
-            # Triggers a peer_relation_changed event in the DatabaseProvidesRelation
-            num_units_bootstrapped = int(self.app_peer_data.get(NUM_UNITS_BOOTSTRAPPED, "0"))
-            self.app_peer_data[NUM_UNITS_BOOTSTRAPPED] = str(num_units_bootstrapped + 1)
-
             return True
 
         return False
@@ -213,6 +217,10 @@ class MySQLRouterOperatorCharm(CharmBase):
     # =======================
     #  Handlers
     # =======================
+
+    def _on_install(self, _) -> None:
+        """Handle the install event."""
+        self.unit.status = WaitingStatus()
 
     def _on_leader_elected(self, _) -> None:
         """Handle the leader elected event.
@@ -228,15 +236,14 @@ class MySQLRouterOperatorCharm(CharmBase):
             logger.exception("Failed to create k8s service", exc_info=e)
             self.unit.status = BlockedStatus("Failed to create k8s service")
             return
-        self.unit.status = WaitingStatus()
 
     def _on_mysql_router_pebble_ready(self, _) -> None:
         """Handle the mysql-router pebble ready event."""
         if self._bootstrap_mysqlrouter():
             self.unit.status = ActiveStatus()
 
-    def _on_update_status(self, _) -> None:
-        """Handle the update status event.
+    def _on_peer_relation_changed(self, _) -> None:
+        """Handle the peer relation changed event.
 
         Bootstraps mysqlrouter if the relations exist, but pebble_ready event
         fired before the requires relation was formed.
@@ -247,6 +254,16 @@ class MySQLRouterOperatorCharm(CharmBase):
             and self._bootstrap_mysqlrouter()
         ):
             self.unit.status = ActiveStatus()
+
+        if self.unit.is_leader():
+            num_units_bootstrapped = sum(
+                [
+                    1
+                    for unit in self._peers.units.union({self.unit})
+                    if self._peers.data[unit].get(UNIT_BOOTSTRAPPED)
+                ]
+            )
+            self.app_peer_data[NUM_UNITS_BOOTSTRAPPED] = str(num_units_bootstrapped)
 
 
 if __name__ == "__main__":

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -52,6 +52,7 @@ class DatabaseProvidesRelation(Object):
         if not self.charm.unit.is_leader():
             return
 
+        # Store data in databag to trigger DatabaseRequires initialization in database_requires.py
         self.charm.app_peer_data[MYSQL_ROUTER_PROVIDES_DATA] = json.dumps(
             {"database": event.database, "extra_user_roles": event.extra_user_roles}
         )

--- a/src/relations/database_requires.py
+++ b/src/relations/database_requires.py
@@ -144,6 +144,11 @@ class DatabaseRequiresRelation(Object):
         self.charm.app_peer_data[MYSQL_DATABASE_CREATED] = "true"
 
     def _on_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
+        """Handle the endpoints changed event.
+
+        Update the endpoint in the MYSQL_ROUTER_REQUIRES_DATA so that future
+        bootstrapping units will not fail.
+        """
         if not self.charm.unit.is_leader():
             return
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import lightkube
-from ops.model import BlockedStatus, WaitingStatus
+from ops.model import BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import MySQLRouterOperatorCharm
@@ -28,7 +28,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(_lightkube_client.return_value.apply.call_count, 2)
 
-        self.assertTrue(isinstance(self.harness.model.unit.status, WaitingStatus))
+        self.assertTrue(isinstance(self.harness.model.unit.status, MaintenanceStatus))
 
     @patch("charm.Client", return_value=MagicMock())
     def test_on_peer_relation_created_delete_exception(self, _lightkube_client):
@@ -50,7 +50,7 @@ class TestCharm(unittest.TestCase):
 
         self.charm.on.leader_elected.emit()
 
-        self.assertTrue(isinstance(self.harness.model.unit.status, WaitingStatus))
+        self.assertTrue(isinstance(self.harness.model.unit.status, MaintenanceStatus))
 
     @patch("charm.Client", return_value=MagicMock())
     def test_on_leader_elected_create_exception(self, _lightkube_client):
@@ -72,4 +72,4 @@ class TestCharm(unittest.TestCase):
 
         self.charm.on.leader_elected.emit()
 
-        self.assertTrue(isinstance(self.harness.model.unit.status, WaitingStatus))
+        self.assertTrue(isinstance(self.harness.model.unit.status, MaintenanceStatus))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import lightkube
-from ops.model import BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
 
 from charm import MySQLRouterOperatorCharm


### PR DESCRIPTION
## Issue
[DPE-1114](https://warthogs.atlassian.net/browse/DPE-1114)
[Issue 11](https://github.com/canonical/mysql-router-k8s-operator/issues/11) and [Issue 12](https://github.com/canonical/mysql-router-k8s-operator/issues/12)

1. When new mysql-router-k8s units are added, they do not go active until the next update-status hook runs (they are not bootstrapped until the next update-status hook)
2. We are blanket setting the unit status as `WaitingStatus` on leader-elected. Thus, if the application leader changes, the status is set to `waiting` even if it is supposed to be `active`

## Solution
1. When we form a relation with the consumer application, we are setting some information in the peer relation (this is exactly when the unit has all the information to be bootstrapped). Thus, bootstrap the unit upon peer-relation-changed and move the unit to `ActiveStatus` immediately.
2. Set the unit to `WaitingStatus` once on the `install` hook handler

## Release Notes
Bootstrap new units as soon as possible instead of doing so in update-status

## Testing
```
charmcraft pack
juju deploy -n 3 --channel edge ./mysql-router-k8s_ubuntu-22.04-amd64.charm --resource mysql-router-image=dataplatf
ormoci/mysql-router:latest mysql-router-k8s
juju deploy -n 3 --channel edge mysql-k8s
juju deploy --trust --channel yoga/edge keystone-k8s

juju relate mysql-k8s mysql-router-k8s
juju relate mysql-router-k8s keystone-k8s
```
With the above, all units but `keystone-k8s` go into `active` status. Unit keystone-k8s/0 is in `blocked` status. I was able to confirm that the relation databag is populated:
```
shayan@wellington:~ (10:21:26)  $ jhack utils show-relation keystone-k8s:database mysql-router-k8s3:database
/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.25.8) or chardet (5.1.0) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
                                                                                            relation data v0.3                                                                                             
┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ relation (id: 11) ┃ mysql-router-k8s3                                                                        ┃ keystone-k8s                                                                             ┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ relation name     │ database                                                                                 │ database                                                                                 │
│ interface         │ mysql_client                                                                             │ mysql_client                                                                             │
│ leader unit       │ 0                                                                                        │ 0                                                                                        │
├───────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
│ application data  │ ╭──────────────────────────────────────────────────────────────────────────────────────╮ │ ╭──────────────────────────────────────────────────────────────────────────────────────╮ │
│                   │ │                                                                                      │ │ │                                                                                      │ │
│                   │ │  data                 {"database": "keystone"}                                       │ │ │  database  keystone                                                                  │ │
│                   │ │  endpoints            mysql-router-k8s3-read-write.deve.svc.cluster.local:6446       │ │ ╰──────────────────────────────────────────────────────────────────────────────────────╯ │
│                   │ │  password             il3ndMXYQep95vH6R6fH9Ezq                                       │ │                                                                                          │
│                   │ │  read-only-endpoints  mysql-router-k8s3-read-only.deve.svc.cluster.local:6447        │ │                                                                                          │
│                   │ │  username             application-user-11                                            │ │                                                                                          │
│                   │ ╰──────────────────────────────────────────────────────────────────────────────────────╯ │                                                                                          │
│ unit data         │ ╭─ mysql-router-k8s3/0* ─╮ ╭─ mysql-router-k8s3/1 ─╮ ╭─ mysql-router-k8s3/2 ─╮           │ ╭─ keystone-k8s/0* ────────────────────────────────────────────────────────────────────╮ │
│                   │ │ <empty>                │ │ <empty>               │ │ <empty>               │           │ │                                                                                      │ │
│                   │ ╰────────────────────────╯ ╰───────────────────────╯ ╰───────────────────────╯           │ │  alias  database                                                                     │ │
│                   │ ╭─ mysql-router-k8s3/3 ──╮                                                               │ │  data   {"endpoints": "mysql-router-k8s3-read-write.deve.svc.cluster.local:6446",    │ │
│                   │ │ <empty>                │                                                               │ │         "password": "il3ndMXYQep95vH6R6fH9Ezq", "read-only-endpoints":               │ │
│                   │ ╰────────────────────────╯                                                               │ │         "mysql-router-k8s3-read-only.deve.svc.cluster.local:6447", "username":       │ │
│                   │                                                                                          │ │         "application-user-11"}                                                       │ │
│                   │                                                                                          │ ╰──────────────────────────────────────────────────────────────────────────────────────╯ │
└───────────────────┴──────────────────────────────────────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────┘
```
Additionally, I ssh'ed into the keystone unit and confirmed that the keystone unit was able to connect to the database:
```
shayan@wellington:~ (10:13:20)  $ kubectl -n deve exec -it keystone-k8s-0  bash                                                                                                                            
root@keystone-k8s-0:/var/lib/juju# mysql -h mysql-router-k8s3-read-write.deve.svc.cluster.local -P 6446 -u application-user-11 -pil3ndMXYQep95vH6R6fH9Ezq                                                 
mysql: [Warning] Using a password on the command line interface can be insecure.
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 12181
Server version: 8.0.31-0ubuntu0.22.04.1 (Ubuntu)

Copyright (c) 2000, 2023, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show databases;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| keystone           |
| performance_schema |
+--------------------+
3 rows in set (0.00 sec)

mysql> use keystone;
Database changed
mysql> show tables;
Empty set (0.00 sec)

mysql> create table test (id int, primary key (id));
Query OK, 0 rows affected (0.09 sec)

mysql> show tables;
+--------------------+
| Tables_in_keystone |
+--------------------+
| test               |
+--------------------+
1 row in set (0.00 sec)

```

[DPE-1114]: https://warthogs.atlassian.net/browse/DPE-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ