### PR TITLE
Fix failing integration-database CI test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,5 @@ jobs:
         uses: canonical/charm-logdump-action@main
         if: failure()
         with:
-          # TEMPLATE-TODO: Replace the application name
-          app: operator-template
+          app: mysql-router-k8s
           model: testing

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 
-MYSQL_APP_NAME = "mysql"
-MYSQL_ROUTER_APP_NAME = "mysqlrouter"
+MYSQL_APP_NAME = "mysql-k8s"
+MYSQL_ROUTER_APP_NAME = "mysql-router-k8s"
 APPLICATION_APP_NAME = "application"
 SLOW_TIMEOUT = 15 * 60
 
@@ -42,7 +42,11 @@ async def test_database_relation(ops_test: OpsTest):
 
     applications = await asyncio.gather(
         ops_test.model.deploy(
-            "mysql-k8s", channel="latest/edge", application_name=MYSQL_APP_NAME, num_units=3
+            MYSQL_APP_NAME,
+            channel="latest/edge",
+            application_name=MYSQL_APP_NAME,
+            num_units=3,
+            trust=True, # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
         ),
         ops_test.model.deploy(
             mysqlrouter_charm,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -46,7 +46,7 @@ async def test_database_relation(ops_test: OpsTest):
             channel="latest/edge",
             application_name=MYSQL_APP_NAME,
             num_units=3,
-            trust=True, # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
+            trust=True,  # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
         ),
         ops_test.model.deploy(
             mysqlrouter_charm,


### PR DESCRIPTION
## Issue
The test was failing to bootstrap mysql-k8s charm due to the recent changes there in commit a6f1f01: Fix/endpoints as k8s services (#142).

Also 'Dump logs' GitHub CI step was failing due to wrong app name used, fixed names to match official charm names (for simplicity).

## Solution
Add missing flag `--trust` to bootstrap `mysql-k8s` and rename apps to match official naming.