### PR TITLE
Delete integration tests for the integration tox target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,6 @@ jobs:
       fail-fast: false
       matrix:
         tox-environments:
-          - integration
           - integration-database
     name: ${{ matrix.tox-environments }}
     needs:


### PR DESCRIPTION
## Issue
There is no longer a tox target `integration`, but the CI runs this tox target. The [test runs nothing before passing](https://github.com/canonical/mysql-router-k8s-operator/actions/runs/4233061331/jobs/7353782863#step:6:10)

## Solution
Remove the `integration` tox target when running CI