### PR TITLE
Update build_charms_with_cache.yaml to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
 
   integration-test:
     strategy:


### PR DESCRIPTION
The major version was bumped because breaking changes were made to another workflow in [data-platform-workflows](https://github.com/canonical/data-platform-workflows).

No breaking changes were made to build_charms_with_cache.yaml ([changelog](https://github.com/canonical/data-platform-workflows/releases/tag/v2.0.0))
