### PR TITLE
Disabling destructive-mode for upload-charm action and update versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,4 +46,4 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
-          destructive-mode: false
+          destructive: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.1.1
+        uses: canonical/charming-actions/check-libraries@2.2.2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -37,12 +37,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.1.1
+        uses: canonical/charming-actions/channel@2.2.2
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.1.1
+        uses: canonical/charming-actions/upload-charm@2.2.2
         with:
           resource-overrides: "mysql-router-image:1"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
+          destructive-mode: false


### PR DESCRIPTION
## Issue

It is not possible to build focal charms on jammy GH runner:
> /usr/bin/sudo charmcraft pack --destructive-mode --quiet
> No suitable 'build-on' environment found in any 'bases' configuration.
> Full execution log: '/root/.local/state/charmcraft/log/charmcraft-20230227-190524.251127.log'

## Solution
Disable ` --destructive-mode -` so `charmcraft pack` will use lxc container to build a charm.