### PR TITLE
Add setup-lxd to release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.2.2
         id: channel


### PR DESCRIPTION
## Issue
Otherwise charming-actions/upload-charm is failing in non-destructive mode:

```
/usr/bin/sudo charmcraft pack --quiet
charmcraft internal error: LXDError(brief='LXD has not been properly initialized.',
details=None, resolution="Execute 'lxd init --auto' to initialize LXD.
Visit https://linuxcontainers.org/lxd/getting-started-cli/ for instructions on installing and configuring LXD for your operating system.")
```

## Solution
Use `setup-lxd` action to make sure LXD is fully usable.