### PR TITLE
Update peer interface names to follow naming conventions

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,7 +25,7 @@ requires:
     limit: 1
 peers:
   mysql-router-peers:
-    interface: mysql-router-peers
+    interface: mysql_router_peers
 resources:
   mysql-router-image:
     type: oci-image


### PR DESCRIPTION
## Issue
The interface name is using `-`, but naming convention says `_`.
https://juju.is/docs/sdk/styleguide

## Solution
The endpoint name should use `-`, but interface name `_`.
