### PR TITLE
Bump juju-agent to 2.9.42, unpin flake8 and remove unnecessary SIMULATE_CAN_CONNECT

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,8 +65,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.42"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,7 +12,7 @@ bases:
 parts:
   charm:
     charm-binary-python-packages:
-      - mysql-connector-python==8.0.30
+      - mysql-connector-python
     build-packages:
       - libffi-dev
       - libssl-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ cryptography==39.0.1
 jsonschema==4.17.3
 lightkube-models==1.24.1.4
 lightkube==0.11.0
+mysql-connector-python
 ops >= 2.0.0
 tenacity==8.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ cryptography==39.0.1
 jsonschema==4.17.3
 lightkube-models==1.24.1.4
 lightkube==0.11.0
-ops >= 1.5.2
+ops >= 2.0.0
 tenacity==8.0.1

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,8 +1,0 @@
-# Copyright 2022 Canonical Ltd.
-# See LICENSE file for licensing details.
-
-import ops.testing
-
-# Since ops>=1.4 this enables better connection tracking.
-# See: More at https://juju.is/docs/sdk/testing#heading--simulate-can-connect
-ops.testing.SIMULATE_CAN_CONNECT = True

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8==5.0.4 # https://github.com/savoirfairelinux/flake8-copyright/issues/19
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -58,7 +58,7 @@ commands =
 description = Run unit tests
 deps =
     Jinja2==3.1.2
-    mysql-connector-python==8.0.30
+    mysql-connector-python~=8.0.32
     pytest
     coverage[toml]
     -r {tox_root}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,6 @@ commands =
 description = Run unit tests
 deps =
     Jinja2==3.1.2
-    mysql-connector-python
     pytest
     coverage[toml]
     -r {tox_root}/requirements.txt
@@ -75,7 +74,6 @@ pass_env =
     CI_PACKED_CHARMS
 deps =
     juju==2.9.38.1
-    mysql-connector-python
     pytest
     pytest-operator
     -r {tox_root}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ commands =
 description = Run unit tests
 deps =
     Jinja2==3.1.2
-    mysql-connector-python~=8.0.32
+    mysql-connector-python
     pytest
     coverage[toml]
     -r {tox_root}/requirements.txt


### PR DESCRIPTION
## Issue
We were using an old juju-agent due to several open issues in 2.9.30+, but none are affecting tests in this repo.

## Solution
Updating juju-agent to the latest 2.9.42.
Also removing no longer necessary pinning for flake8, bumping ops pinning and removing not necessary SIMULATE_CAN_CONNECT (it is enabled by default for ops 2.0+).