### PR TITLE
DPE-1656 Limit tests RAM usage by every unit/container to 1Gb

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          bootstrap-options: "--agent-version 2.9.42"
+          bootstrap-options: "--agent-version 2.9.42 --constraints mem=1G"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
## Issue
Often and strange tests crashes on GH runner while all is OK on localhost.

## Solution
GH Runners have 8GB RAM only. We are launching 1-2 MySQL clusters with three units each and allocating 50% for innodb_buffer_pull_size. OOM is an often trouble in this case.