### PR TITLE
Clear database_provides databags when MySQL relation broken

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -204,9 +204,12 @@ class MySQLRouterOperatorCharm(ops.CharmBase):
             f"{self.unit.is_leader()=}, "
             f"{isinstance(workload_, workload.AuthenticatedWorkload)=}, "
             f"{workload_.container_ready=}, "
+            f"{self.database_requires.is_relation_breaking(event)=}, "
             f"{isinstance(event, ops.UpgradeCharmEvent)=}"
         )
-        if (
+        if self.unit.is_leader() and self.database_requires.is_relation_breaking(event):
+            self.database_provides.delete_all_databags()
+        elif (
             self.unit.is_leader()
             and isinstance(workload_, workload.AuthenticatedWorkload)
             and workload_.container_ready


### PR DESCRIPTION
When the MySQL relation is re-established, it could be a different MySQL cluster—new users will need to be created.

## Issue
Fixes #80
The MySQL charm will delete the users when the MySQL <-> MySQL Router relation broken. However, the users are not being removed from the MySQL Router <-> Application relation databags