### PR TITLE
Update bug_report.md issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,6 +8,7 @@ labels: bug
 <!-- Thank you for submitting a bug report! All fields are required unless marked optional. -->
 
 ## Steps to reproduce
+<!-- Please enable debug logging by running `juju model-config logging-config="<root>=INFO;unit=DEBUG"` (if possible) -->
 1. 
 
 ## Expected behavior
@@ -19,25 +20,26 @@ labels: bug
 
 ## Versions
 
-<!-- Run "lsb_release -sd" -->
+<!-- Run `lsb_release -sd` -->
 Operating system: 
 
-<!-- Run "juju version" -->
+<!-- Run `juju version` -->
 Juju CLI: 
 
-<!-- Model version from "juju status" -->
+<!-- Model version from `juju status` -->
 Juju agent: 
 
-<!-- App revision from "juju status" or (advanced) commit hash -->
+<!-- App revision from `juju status` or (advanced) commit hash -->
 mysql-k8s charm revision: 
 mysql-router-k8s charm revision: 
 
-<!-- Run "microk8s version" -->
+<!-- Run `microk8s version` -->
 microk8s: 
 
 ## Log output
-<!-- Run "juju debug-log --replay > juju-debug-log.txt" and upload "juju-debug-log.txt" file here -->
-
+<!-- Please enable debug logging by running `juju model-config logging-config="<root>=INFO;unit=DEBUG"` (if possible) -->
+<!-- Then, run `juju debug-log --replay > log.txt` and upload "log.txt" file here -->
+Juju debug log: 
 
 <!-- (Optional) Copy the logs that are relevant to the bug & paste inside triple backticks below -->
 


### PR DESCRIPTION
The full `juju debug-log` usually exceeds GitHub's character limit, so it's better to upload it as a file instead of copy-pasting it into the issue
