### PR TITLE
Only check for container restart before workload enabled

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -237,13 +237,6 @@ class MySQLRouterOperatorCharm(ops.CharmBase):
 
     def _on_mysql_router_pebble_ready(self, _) -> None:
         self.unit.set_workload_version(self.get_workload(event=None).version)
-        workload_ = self.get_workload(event=None)
-        if isinstance(workload_, workload.AuthenticatedWorkload):
-            # If this is not the first pebble ready event (for this unit), the container
-            # restarted. MySQL Router may have already been bootstrapped on this unit but MySQL
-            # Router's config file was lost during container restart—clean up the old MySQL Router
-            # instance.
-            workload_.cleanup_after_potential_container_restart(unit_name=self.unit.name)
         self.reconcile_database_relations()
 
     def _on_leader_elected(self, _) -> None:


### PR DESCRIPTION
During scale up, MySQL Router can bootstrap before the pebble ready event is fired (because in a previous event, the container is ready—even though the event hasn't fired). As a result, the user & cluster metadata are deleted (and not re-created). Fixes https://github.com/canonical/mysql-router-k8s-operator/issues/94

Instead of checking for container restart on mysql_pebble_ready, check for container restart in Workload().enable()

This approach should also handle any race conditions where a relation event (or other event that calls reconcile_database_relations) fires after a pod restart but before pebble ready