### PR TITLE
Use `relation_created` instead of `relation_joined`

### DIFF
--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -148,7 +148,7 @@ class RelationEndpoint:
     def __init__(self, charm_: "abstract_charm.MySQLRouterCharm") -> None:
         self._interface = data_interfaces.DatabaseProvides(charm_, relation_name=self._NAME)
         charm_.framework.observe(
-            charm_.on[self._NAME].relation_joined,
+            charm_.on[self._NAME].relation_created,
             charm_.reconcile_database_relations,
         )
         charm_.framework.observe(

--- a/src/relations/tls.py
+++ b/src/relations/tls.py
@@ -198,7 +198,7 @@ class RelationEndpoint(ops.Object):
             self._on_set_tls_private_key,
         )
         self.framework.observe(
-            self._charm.on[self.NAME].relation_joined, self._on_tls_relation_joined
+            self._charm.on[self.NAME].relation_created, self._on_tls_relation_created
         )
         self.framework.observe(
             self._charm.on[self.NAME].relation_broken, self._on_tls_relation_broken
@@ -281,8 +281,8 @@ class RelationEndpoint(ops.Object):
                 raise
         logger.debug("Handled set TLS private key action")
 
-    def _on_tls_relation_joined(self, _) -> None:
-        """Request certificate when TLS relation joined."""
+    def _on_tls_relation_created(self, _) -> None:
+        """Request certificate when TLS relation created."""
         self._relation.request_certificate_creation()
 
     def _on_tls_relation_broken(self, _) -> None:


### PR DESCRIPTION
The handlers are supposed to run when the relation is created, not when a unit joins the relation
