### PR TITLE
Pass `PurePath` to ops.Container methods instead of str

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ cryptography==39.0.1
 jsonschema==4.17.3
 lightkube-models==1.24.1.4
 lightkube==0.11.0
-ops >= 2.0.0
+ops >= 2.4.0
 tenacity==8.0.1

--- a/src/rock.py
+++ b/src/rock.py
@@ -45,20 +45,16 @@ class _Path(container.Path):
         )
 
     def unlink(self, missing_ok=False):
-        # TODO: use `self` instead of `str(self)` after next ops release
-        path = str(self)
-        if missing_ok and not self._container.exists(path):
+        if missing_ok and not self._container.exists(self):
             return
-        self._container.remove_path(path)
-        logger.debug(f"Deleted file {path=}")
+        self._container.remove_path(self)
+        logger.debug(f"Deleted file {self=}")
 
     def mkdir(self):
-        # TODO: use `self` instead of `str(self)` after next ops release
-        self._container.make_dir(str(self), user=_UNIX_USERNAME, group=_UNIX_USERNAME)
+        self._container.make_dir(self, user=_UNIX_USERNAME, group=_UNIX_USERNAME)
 
     def rmtree(self):
-        # TODO: use `self` instead of `str(self)` after next ops release
-        self._container.remove_path(str(self), recursive=True)
+        self._container.remove_path(self, recursive=True)
 
 
 class Rock(container.Container):


### PR DESCRIPTION
Update ops to 2.4.0 (for https://github.com/canonical/operator/pull/946)
