### PR TITLE
Add missing permissions to release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,8 @@ jobs:
     needs:
       - lib-check
     uses: ./.github/workflows/ci.yaml
+    permissions:
+      actions: write  # Needed to manage GitHub Actions cache
 
   build:
     name: Build charm


### PR DESCRIPTION
Fixes broken release CI: https://github.com/canonical/mysql-router-k8s-operator/actions/runs/5554887264

Follow-up to #108
