### PR TITLE
Remove ops version constraint for ops-scenario issue

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2188,4 +2188,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "81b8640ec9f093b52efd684798c0e4f847fcf3beb4b0813d0c22349a27516373"
+content-hash = "159c0fd6ea0474886f6fb3530b1708c87542273a0b549f5b4a4eb1bc9a195afb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ codespell = "^2.2.5"
 pytest = "^7.4.0"
 pytest-xdist = "^3.3.1"
 pytest-cov = "^4.1.0"
-ops-scenario = "^5.1.2"
+ops-scenario = "^5.2"
 
 [tool.poetry.group.integration.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
Fixed in https://github.com/canonical/ops-scenario/pull/50
