### PR TITLE
DPE-2752 Add Discourse documentation + update metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,16 +1,23 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 name: mysql-router-k8s
 display-name: MySQL Router
-maintainers:
-  - Carl Csaposs <carl.csaposs@canonical.com>
-  - Paulo Machado <paulo.machado@canonical.com>
-  - Shayan Patel <shayan.patel@canonical.com>
+summary: Charmed K8s operator for mysql-router.
 description: |
-  K8S charmed operator for mysql-router.
-summary: |
-  Charmed operator for mysql-router.
   Enables effective access to group replicated MySQL cluster for client applications.
+
+  This charm supports MySQL Router 8.0 in Kubernetes environments.
+docs: https://discourse.charmhub.io/t/charmed-mysql-router-k8s-documentation/12130
+source: https://github.com/canonical/mysql-router-k8s-operator
+issues: https://github.com/canonical/mysql-router-k8s-operator/issues
+website:
+  - https://ubuntu.com/data/mysql
+  - https://charmhub.io/mysql-router-k8s
+  - https://github.com/canonical/mysql-router-k8s-operator
+  - https://chat.charmhub.io/charmhub/channels/data-platform
+maintainers:
+  - Canonical Data Platform <data-platform@lists.launchpad.net>
+
 containers:
   mysql-router:
     resource: mysql-router-image

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,10 +1,10 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 name: mysql-router-k8s
-display-name: MySQL Router
+display-name: MySQL Router K8s
 summary: Charmed K8s operator for mysql-router.
 description: |
-  Enables effective access to group replicated MySQL cluster for client applications.
+  Enables effective access to a MySQL cluster with Group Replication.
 
   This charm supports MySQL Router 8.0 in Kubernetes environments.
 docs: https://discourse.charmhub.io/t/charmed-mysql-router-k8s-documentation/12130

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 name: mysql-router-k8s
 display-name: MySQL Router K8s
-summary: Charmed K8s operator for mysql-router.
+summary: Charmed MySQL Router K8s operator
 description: |
   Enables effective access to a MySQL cluster with Group Replication.
 


### PR DESCRIPTION
## Issue

* documentation on Discourse was missing
* metadata.yaml was outdated (missing lings, outdated year, wrong summary, etc)

## Solution

We are preparing the charm for release to stable and need to
generate all the necessary documentation/links on https://charmhub.io/mysql-router-k8s
* update metadata.yaml to match mysql-k8s concepts
* add Discourse documentation Overview page
