### PR TITLE
Fix upgrade bug

### DIFF
--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -226,7 +226,7 @@ class Upgrade(abc.ABC):
             for upgrade_order_index, unit in enumerate(units):
                 # Note: upgrade_order_index != unit number
                 if (
-                    force is False and self._peer_relation.data[unit].get("state") != "healthy"
+                    not force and self._peer_relation.data[unit].get("state") != "healthy"
                 ) or self._unit_workload_versions[unit.name] != self._app_workload_version:
                     if not action_event and upgrade_order_index == 1:
                         # User confirmation needed to resume upgrade (i.e. upgrade second unit)


### PR DESCRIPTION
`force` was `None` if `action_event` was `None` so `force is False` evaluated to `False` when it should have evaluated to `True`
