### PR TITLE
Increase log level of root logger

### DIFF
--- a/src/abstract_charm.py
+++ b/src/abstract_charm.py
@@ -18,7 +18,7 @@ import relations.database_requires
 import upgrade
 import workload
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 
 class MySQLRouterCharm(ops.CharmBase, abc.ABC):
@@ -26,6 +26,14 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
 
     def __init__(self, *args) -> None:
         super().__init__(*args)
+        # `ops` adds juju debug-log handler to root logger and sets the root logger level to DEBUG
+        # The root logger will receive log messages from our Python dependencies (e.g. lightkube)
+        # which clutters juju debug-log.
+        # Set root logger level
+        logging.getLogger().setLevel(logging.WARNING)
+        # Set charm logger level
+        logging.getLogger("router_charm").setLevel(logging.DEBUG)
+
         # Instantiate before registering other event observers
         self._unit_lifecycle = lifecycle.Unit(
             self, subordinated_relation_endpoint_names=self._subordinate_relation_endpoint_names

--- a/src/kubernetes_charm.py
+++ b/src/kubernetes_charm.py
@@ -22,7 +22,7 @@ import relations.tls
 import rock
 import upgrade
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 
 class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):

--- a/src/kubernetes_upgrade.py
+++ b/src/kubernetes_upgrade.py
@@ -19,7 +19,7 @@ import ops
 
 import upgrade
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 
 class DeployedWithoutTrust(Exception):

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -11,7 +11,7 @@ import typing
 
 import ops
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 
 class _UnitTearingDownAndAppActive(enum.IntEnum):

--- a/src/mysql_shell.py
+++ b/src/mysql_shell.py
@@ -15,7 +15,7 @@ import typing
 
 import container
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 _PASSWORD_LENGTH = 24
 

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -16,7 +16,7 @@ import status_exception
 if typing.TYPE_CHECKING:
     import abstract_charm
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 
 class _RelationBreaking(Exception):

--- a/src/relations/database_requires.py
+++ b/src/relations/database_requires.py
@@ -15,7 +15,7 @@ import status_exception
 if typing.TYPE_CHECKING:
     import abstract_charm
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 
 class _MissingRelation(status_exception.StatusException):

--- a/src/relations/remote_databag.py
+++ b/src/relations/remote_databag.py
@@ -11,7 +11,7 @@ import ops
 
 import status_exception
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 
 class IncompleteDatabag(status_exception.StatusException):

--- a/src/relations/tls.py
+++ b/src/relations/tls.py
@@ -18,7 +18,7 @@ import ops
 if typing.TYPE_CHECKING:
     import kubernetes_charm
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 _PEER_RELATION_ENDPOINT_NAME = "mysql-router-peers"
 

--- a/src/rock.py
+++ b/src/rock.py
@@ -11,7 +11,7 @@ import ops
 
 import container
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 CONTAINER_NAME = "mysql-router"
 _UNIX_USERNAME = "mysql"

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -16,7 +16,7 @@ import typing
 import ops
 import poetry.core.constraints.version as poetry_version
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 PEER_RELATION_ENDPOINT_NAME = "upgrade-version-a"
 RESUME_ACTION_NAME = "resume-upgrade"

--- a/src/workload.py
+++ b/src/workload.py
@@ -19,7 +19,7 @@ if typing.TYPE_CHECKING:
     import abstract_charm
     import relations.database_requires
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"router_charm.{__name__}")
 
 
 class Workload:


### PR DESCRIPTION
`ops` adds juju debug-log handler to root logger—meaning all Python dependencies log to juju debug-log

lightkube's DEBUG and INFO level logs are particularly noisy and clutter up the debug log

Set root level logger to WARNING and only send DEBUG and INFO level logs to juju debug-log if the log is in the charm code
