### PR TITLE
Use MaintenanceStatus instead of Waiting while router is starting

### DIFF
--- a/src/abstract_charm.py
+++ b/src/abstract_charm.py
@@ -152,7 +152,7 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
         Retry every 5 seconds for up to 30 seconds.
         """
         logger.debug("Waiting until MySQL Router is ready")
-        self.unit.status = ops.WaitingStatus("MySQL Router starting")
+        self.unit.status = ops.MaintenanceStatus("MySQL Router starting")
         try:
             for attempt in tenacity.Retrying(
                 reraise=True,


### PR DESCRIPTION
WaitingStatus should be used when the workload is healthy and waiting on other units/apps

MaintenanceStatus should be used when the workload is not providing service & we're waiting on this unit
