### PR TITLE
Fix upgrade compatability check

### DIFF
--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -85,8 +85,7 @@ class Upgrade(abc.ABC):
         }
         try:
             if (
-                # TODO charm versioning: Use > instead of >=
-                previous_versions["charm"] >= current_versions["charm"]
+                previous_versions["charm"] > current_versions["charm"]
                 or previous_versions["charm"].major != current_versions["charm"].major
             ):
                 logger.debug(


### PR DESCRIPTION
Charm should always be able to upgrade to its own version (so that rollbacks are allowed without force)