### PR TITLE
[DPE-3063] Update logrotate dateformat to tolerate more than 24hrs of uptime

### DIFF
--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -11,7 +11,7 @@ rotate 10800
 
 # Naming of rotated files should be in the format:
 dateext
-dateformat -%V_%H%M
+dateformat -%Y%m%d_%H:%M
 
 # Settings to prevent misconfigurations and unwanted behaviours
 ifempty


### PR DESCRIPTION
## Issue
We are using `-%V_%H%M` as the dateformat for logrotate - this causes filename conflicts after a day of uptime due to file name conflicts.

## Solution
Use `-%Y%m%d_%H:%M` as the dateformat (for consistency with pgbouncer)