### PR TITLE
Set `httpx` and `httpcore` logger level to WARNING

### DIFF
--- a/src/kubernetes_charm.py
+++ b/src/kubernetes_charm.py
@@ -25,6 +25,7 @@ import rock
 import upgrade
 
 logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 


### PR DESCRIPTION
`httpx` and `httpcore` (used by `lightkube`) have noisy INFO & DEBUG level logs

Supersedes #145. It still seems a bit backwards to me to enable DEBUG level logs for all python dependencies and then manually disable logging for dependencies of our dependencies. Personally, I only think DEBUG level logs are useful for charm ecosystem code (e.g. ops, the charm, charm libs)—but it seems like the consensus [from this discussion](https://github.com/canonical/mysql-router-k8s-operator/pull/145#discussion_r1365706375) is different