### PR TITLE
Disconnect mysqlsh

### DIFF
--- a/src/mysql_shell.py
+++ b/src/mysql_shell.py
@@ -52,6 +52,7 @@ class Shell:
         commands.insert(
             0, f"shell.connect('{self.username}:{self._password}@{self._host}:{self._port}')"
         )
+        commands.append("shell.disconnect()")
         temporary_script_file = self._container.path("/tmp/script.py")
         temporary_script_file.write_text("\n".join(commands))
         try:


### PR DESCRIPTION
mysqlsh leaves connections open if disconnect is not called, which can cause mysql server to exceed its maximum connections