### PR TITLE
Enable poetry hashes & charmcraft strict dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v7.0.0
+    with:
+      charmcraft-snap-channel: beta
     permissions:
       actions: write  # Needed to manage GitHub Actions cache
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,8 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v7.0.0
+    with:
+      charmcraft-snap-channel: beta
 
   release:
     name: Release charm

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -18,6 +18,7 @@ parts:
           echo 'ERROR: Use "tox run -e build" instead of calling "charmcraft pack" directly' >&2
           exit 1
       fi
+    charm-strict-dependencies: true
     charm-entrypoint: src/kubernetes_charm.py
     prime:
       - charm_version

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,7 @@ commands_pre =
     # is pending review.
     python -c 'import pathlib; import shutil; import subprocess; git_hash=subprocess.run(["git", "describe", "--always", "--dirty"], capture_output=True, check=True, encoding="utf-8").stdout; file = pathlib.Path("charm_version"); shutil.copy(file, pathlib.Path("charm_version.backup")); version = file.read_text().strip(); file.write_text(f"{version}+{git_hash}")'
 
-    # `--without-hashes` workaround for https://github.com/canonical/charmcraft/issues/1179
-    poetry export --only main,charm-libs --output requirements.txt --without-hashes
+    poetry export --only main,charm-libs --output requirements.txt
 commands =
     build: charmcraft pack {posargs}
 commands_post =


### PR DESCRIPTION
charmcraft strict dependencies prevents PYDEPS from overriding pinned dependencies (and requires that we manage PYDEPS dependencies with poetry)