### PR TITLE
[DPE-3771] Add node port support

### DIFF
--- a/src/abstract_charm.py
+++ b/src/abstract_charm.py
@@ -249,7 +249,6 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
         if not self._upgrade.versions_set:
             logger.debug("Peer relation not ready")
             return
-
         workload_ = self.get_workload(event=event)
         if self._upgrade.unit_state == "restarting":  # Kubernetes only
             if not self._upgrade.is_compatible:
@@ -298,7 +297,6 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
                     and workload_.container_ready
                 ):
                     self._reconcile_node_port(event=event)
-
                     self._database_provides.reconcile_users(
                         event=event,
                         router_read_write_endpoint=self._read_write_endpoint,

--- a/src/abstract_charm.py
+++ b/src/abstract_charm.py
@@ -225,7 +225,7 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
             logger.debug("MySQL Router is ready")
 
     @abc.abstractmethod
-    def _reconcile_node_port(self, event=None) -> None:
+    def _reconcile_node_port(self, event) -> None:
         """Reconcile node port.
 
         Only applies to Kubernetes charm

--- a/src/abstract_charm.py
+++ b/src/abstract_charm.py
@@ -225,7 +225,7 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
             logger.debug("MySQL Router is ready")
 
     @abc.abstractmethod
-    def _reconcile_node_port(self) -> None:
+    def _reconcile_node_port(self, event=None) -> None:
         """Reconcile node port.
 
         Only applies to Kubernetes charm
@@ -297,7 +297,7 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
                     and isinstance(workload_, workload.AuthenticatedWorkload)
                     and workload_.container_ready
                 ):
-                    self._reconcile_node_port()
+                    self._reconcile_node_port(event=event)
 
                     self._database_provides.reconcile_users(
                         event=event,

--- a/src/abstract_charm.py
+++ b/src/abstract_charm.py
@@ -84,13 +84,25 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
     def _logrotate(self) -> logrotate.LogRotate:
         """logrotate"""
 
+    @property
     @abc.abstractmethod
-    def _read_write_endpoint(self, relation=None, is_internal: bool = True) -> str:
+    def _read_write_endpoint(self) -> str:
         """MySQL Router read-write endpoint"""
 
+    @property
     @abc.abstractmethod
-    def _read_only_endpoint(self, relation=None, is_internal: bool = True) -> str:
+    def _read_only_endpoint(self) -> str:
         """MySQL Router read-only endpoint"""
+
+    @property
+    @abc.abstractmethod
+    def _exposed_read_write_endpoint(self) -> str:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def _exposed_read_only_endpoint(self) -> str:
+        pass
 
     @property
     def _tls_certificate_saved(self) -> bool:
@@ -301,10 +313,10 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
 
                     self._database_provides.reconcile_users(
                         event=event,
-                        router_read_write_endpoint=self._read_write_endpoint(),
-                        router_read_only_endpoint=self._read_only_endpoint(),
-                        exposed_read_write_endpoint=self._read_write_endpoint(is_internal=False),
-                        exposed_read_only_endpoint=self._read_only_endpoint(is_internal=False),
+                        router_read_write_endpoint=self._read_write_endpoint,
+                        router_read_only_endpoint=self._read_only_endpoint,
+                        exposed_read_write_endpoint=self._exposed_read_write_endpoint,
+                        exposed_read_only_endpoint=self._exposed_read_only_endpoint,
                         shell=workload_.shell,
                     )
             if workload_.container_ready:

--- a/src/abstract_charm.py
+++ b/src/abstract_charm.py
@@ -225,23 +225,8 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
             logger.debug("MySQL Router is ready")
 
     @abc.abstractmethod
-    def expose(self) -> None:
-        """Expose MySQL Router."""
-        pass
-
-    @abc.abstractmethod
-    def unexpose(self) -> None:
-        """Unexpose MySQL Router."""
-        pass
-
-    def reconcile_node_port(self) -> None:
+    def reconcile_node_port(self, event) -> None:
         """Reconcile node port."""
-        if not self._unit_lifecycle.authorized_leader:
-            return
-        if self._database_provides.is_exposed:
-            self.expose()
-        else:
-            self.unexpose()
 
     # =======================
     #  Handlers
@@ -309,7 +294,7 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
                     and isinstance(workload_, workload.AuthenticatedWorkload)
                     and workload_.container_ready
                 ):
-                    self.reconcile_node_port()
+                    self.reconcile_node_port(event)
 
                     self._database_provides.reconcile_users(
                         event=event,
@@ -328,8 +313,6 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
                     certificate=self._tls_certificate,
                     certificate_authority=self._tls_certificate_authority,
                 )
-            else:
-                self.unexpose()
             # Empty waiting status means we're waiting for database requires relation before
             # starting workload
             if not workload_.status or workload_.status == ops.WaitingStatus():

--- a/src/abstract_charm.py
+++ b/src/abstract_charm.py
@@ -225,8 +225,11 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
             logger.debug("MySQL Router is ready")
 
     @abc.abstractmethod
-    def reconcile_node_port(self, event) -> None:
-        """Reconcile node port."""
+    def _reconcile_node_port(self) -> None:
+        """Reconcile node port.
+
+        Only applies to Kubernetes charm
+        """
 
     # =======================
     #  Handlers
@@ -294,7 +297,7 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
                     and isinstance(workload_, workload.AuthenticatedWorkload)
                     and workload_.container_ready
                 ):
-                    self.reconcile_node_port(event)
+                    self._reconcile_node_port()
 
                     self._database_provides.reconcile_users(
                         event=event,

--- a/src/kubernetes_charm.py
+++ b/src/kubernetes_charm.py
@@ -84,17 +84,7 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
 
     def reconcile_node_port(self, event) -> None:
         """Reconcile node port."""
-        if (
-            isinstance(event, ops.charm.RelationEvent)
-            and self._database_provides.external_connectivity
-            and self.unit.is_leader()
-            and not self._upgrade.in_progress
-        ):
-            # This is going to be called in any of the following cases:
-            # - The relation is created: we need to verify if we should expose the service
-            # - The relation is updated: we need to verify if we should expose the service
-            # - The relation is broken: we need to verify if we should unexpose the service
-            self._patch_service()
+        self._patch_service()
 
     @property
     def model_service_domain(self) -> str:

--- a/src/kubernetes_charm.py
+++ b/src/kubernetes_charm.py
@@ -107,15 +107,21 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
         # Example: mysql-router-k8s.my-model.svc.cluster.local
         return f"{self.app.name}.{self.model_service_domain}"
 
-    def _read_write_endpoint(self, relation=None, is_internal: bool = True) -> str:
-        if not is_internal and self._database_provides.is_exposed:
-            return f"{self.get_k8s_node_ip()}:{self.node_port('rw')}"
+    @property
+    def _read_write_endpoint(self) -> str:
         return f"{self._host}:{self._READ_WRITE_PORT}"
 
-    def _read_only_endpoint(self, relation=None, is_internal: bool = True) -> str:
-        if not is_internal and self._database_provides.is_exposed:
-            return f"{self.get_k8s_node_ip()}:{self.node_port('ro')}"
+    @property
+    def _read_only_endpoint(self) -> str:
         return f"{self._host}:{self._READ_ONLY_PORT}"
+
+    @property
+    def _exposed_read_write_endpoint(self) -> str:
+        return f"{self.get_k8s_node_ip()}:{self.node_port('rw')}"
+
+    @property
+    def _exposed_read_only_endpoint(self) -> str:
+        return f"{self.get_k8s_node_ip()}:{self.node_port('ro')}"
 
     def _patch_service(self, unexpose: bool = False) -> None:
         """Patch Juju-created k8s service.

--- a/src/kubernetes_charm.py
+++ b/src/kubernetes_charm.py
@@ -82,9 +82,9 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
         except upgrade.PeerRelationNotReady:
             pass
 
-    def _reconcile_node_port(self, event=None) -> None:
+    def _reconcile_node_port(self, event) -> None:
         """Reconcile node port."""
-        self._patch_service()
+        self._patch_service(event)
 
     @property
     def model_service_domain(self) -> str:

--- a/src/kubernetes_charm.py
+++ b/src/kubernetes_charm.py
@@ -248,7 +248,8 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
         service = lightkube.Client().get(
             lightkube.resources.core_v1.Service, self.app.name, namespace=self._namespace
         )
-        assert service and service.spec.type == "NodePort"
+        if not service or not service.spec.type == "NodePort":
+            return -1
         # svc.spec.ports
         # [ServicePort(port=3306, appProtocol=None, name=None, nodePort=31438, protocol='TCP', targetPort=3306)]
         port = self._READ_ONLY_PORT if port_type == "ro" else self._READ_WRITE_PORT

--- a/src/kubernetes_charm.py
+++ b/src/kubernetes_charm.py
@@ -13,7 +13,7 @@ import typing
 import lightkube
 import lightkube.models.core_v1
 import lightkube.models.meta_v1
-import lightkube.resources.core_v1 as core_v1
+import lightkube.resources.core_v1
 import ops
 
 import abstract_charm
@@ -185,7 +185,9 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
     def _get_node_name_for_pod(self) -> str:
         """Return the node name for a given pod."""
         pod = self.client.get(
-            core_v1.Pod, name=self.unit.name.replace("/", "-"), namespace=self._namespace
+            lightkube.resources.core_v1.Pod,
+            name=self.unit.name.replace("/", "-"),
+            namespace=self._namespace,
         )
         return pod.spec.nodeName
 
@@ -210,7 +212,9 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
     def get_all_k8s_node_hostnames_and_ips(self) -> typing.Tuple[typing.List[str]]:
         """Return all node hostnames and IPs registered in k8s."""
         node = self.client.get(
-            core_v1.Node, name=self._get_node_name_for_pod(), namespace=self._namespace
+            lightkube.resources.core_v1.Node,
+            name=self._get_node_name_for_pod(),
+            namespace=self._namespace,
         )
         hostnames, ips = [], []
         for a in node.status.addresses:
@@ -223,7 +227,9 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
     def get_k8s_node_ip(self) -> typing.Optional[str]:
         """Return node IP."""
         node = self.client.get(
-            core_v1.Node, name=self._get_node_name_for_pod(), namespace=self._namespace
+            lightkube.resources.core_v1.Node,
+            name=self._get_node_name_for_pod(),
+            namespace=self._namespace,
         )
         # [
         #    NodeAddress(address='192.168.0.228', type='InternalIP'),
@@ -240,7 +246,9 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
 
     def node_port(self, port_type="rw") -> int:
         """Return node port."""
-        service = self.client.get(core_v1.Service, self.app.name, namespace=self._namespace)
+        service = self.client.get(
+            lightkube.resources.core_v1.Service, self.app.name, namespace=self._namespace
+        )
         assert service and service.spec.type == "NodePort"
         # svc.spec.ports
         # [ServicePort(port=3306, appProtocol=None, name=None, nodePort=31438, protocol='TCP', targetPort=3306)]

--- a/src/kubernetes_charm.py
+++ b/src/kubernetes_charm.py
@@ -82,7 +82,7 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
         except upgrade.PeerRelationNotReady:
             pass
 
-    def _reconcile_node_port(self) -> None:
+    def _reconcile_node_port(self, event=None) -> None:
         """Reconcile node port."""
         self._patch_service()
 
@@ -119,7 +119,7 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
     def _exposed_read_only_endpoint(self) -> str:
         return f"{self._node_ip}:{self._node_port('ro')}"
 
-    def _patch_service(self) -> None:
+    def _patch_service(self, event=None) -> None:
         """Patch Juju-created k8s service.
 
         The k8s service will be tied to pod-0 so that the service is auto cleaned by
@@ -155,7 +155,9 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
                     ),
                 ],
                 type=(
-                    "NodePort" if self._database_provides.external_connectivity else "ClusterIP"
+                    "NodePort"
+                    if self._database_provides.external_connectivity(event)
+                    else "ClusterIP"
                 ),
                 selector={"app.kubernetes.io/name": self.app.name},
             ),

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -82,8 +82,7 @@ class _RelationThatRequestedUser(_Relation):
         return any(
             "true" in field.values()
             for field in self._interface.fetch_my_relation_data(
-                relation_ids=[self._id],
-                fields=["external-node-connectivity"]
+                relation_ids=[self._id], fields=["external-node-connectivity"]
             ).values()
         )
 

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -82,6 +82,7 @@ class _RelationThatRequestedUser(_Relation):
         return any(
             "true" in field.values()
             for field in self._interface.fetch_my_relation_data(
+                relation_ids=[self._id],
                 fields=["external-node-connectivity"]
             ).values()
         )
@@ -277,7 +278,8 @@ class RelationEndpoint:
             if relation not in requested_users:
                 relation.delete_user(shell=shell)
         logger.debug(
-            f"Reconciled users {event=}, {router_read_write_endpoint=}, {router_read_only_endpoint=}"
+            f"Reconciled users {event=}, {router_read_write_endpoint=}, {router_read_only_endpoint=}, "
+            f"{exposed_read_write_endpoint=}, {exposed_read_only_endpoint=}"
         )
 
     def delete_all_databags(self) -> None:

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -78,10 +78,13 @@ class _RelationThatRequestedUser(_Relation):
 
     @property
     def external_connectivity(self) -> bool:
-        """Whether any of the relations are marked as exposed."""
-        return set(
-            self._interface.fetch_my_relation_data(fields=["external-node-connectivity"]).values()
-        ) == {"true"}
+        """Whether any of the relations are marked as external."""
+        return any(
+            "true" in field.values()
+            for field in self._interface.fetch_my_relation_data(
+                fields=["external-node-connectivity"]
+            ).values()
+        )
 
     def _set_databag(
         self,

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -233,7 +233,6 @@ class RelationEndpoint:
             f"Reconciling users {event=}, {router_read_write_endpoint=}, {router_read_only_endpoint=}, "
             f"{exposed_read_write_endpoint=}, {exposed_read_only_endpoint=}"
         )
-
         requested_users = []
         for relation in self._interface.relations:
             try:
@@ -248,7 +247,6 @@ class RelationEndpoint:
                 _UnsupportedExtraUserRole,
             ):
                 pass
-
         logger.debug(f"State of reconcile users {requested_users=}, {self._shared_users=}")
         for relation in requested_users:
             if relation not in self._shared_users:
@@ -259,7 +257,6 @@ class RelationEndpoint:
                     exposed_read_only_endpoint=exposed_read_only_endpoint,
                     shell=shell,
                 )
-
         for relation in self._shared_users:
             if relation not in requested_users:
                 relation.delete_user(shell=shell)

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -237,7 +237,9 @@ class RelationEndpoint:
             f"{exposed_read_write_endpoint=}, {exposed_read_only_endpoint=}"
         )
 
-        logger.debug(f"State of reconcile users {self._requested_users(event)=}, {self._shared_users=}")
+        logger.debug(
+            f"State of reconcile users {self._requested_users(event)=}, {self._shared_users=}"
+        )
         for request in self._requested_users(event):
             relation = request.relation
             if request not in self._shared_users:

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -70,27 +70,15 @@ class _RelationThatRequestedUser(_Relation):
         # Application charm databag
         databag = remote_databag.RemoteDatabag(interface=interface, relation=relation)
         self._database: str = databag["database"]
+        # Whether endpoints should be externally accessible
+        # (e.g. when related to `data-integrator` charm)
+        # Implements DA073 - Add Expose Flag to the Database Interface
+        # https://docs.google.com/document/d/1Y7OZWwMdvF8eEMuVKrqEfuFV3JOjpqLHL7_GPqJpRHU
+        self.external_connectivity = databag.get("external-node-connectivity") == "true"
         if databag.get("extra-user-roles"):
             raise _UnsupportedExtraUserRole(
                 app_name=relation.app.name, endpoint_name=relation.name
             )
-
-    @property
-    def external_connectivity(self) -> bool:
-        """Whether endpoints should be externally accessible
-
-        (e.g. when related to `data-integrator` charm)
-
-        Implements DA073 - Add Expose Flag to the Database Interface
-
-        https://docs.google.com/document/d/1Y7OZWwMdvF8eEMuVKrqEfuFV3JOjpqLHL7_GPqJpRHU
-        """
-        return any(
-            "true" in field.values()
-            for field in self._interface.fetch_relation_data(
-                relation_ids=[self._id], fields=["external-node-connectivity"]
-            ).values()
-        )
 
     def _set_databag(
         self,

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -78,11 +78,10 @@ class _RelationThatRequestedUser(_Relation):
 
     @property
     def external_connectivity(self) -> bool:
-        """Whether the relation is exposed."""
-        return (
-            self._relation.data[self._relation.app].get("external-node-connectivity", "false")
-            == "true"
-        )
+        """Whether any of the relations are marked as exposed."""
+        return set(
+            self._interface.fetch_my_relation_data(fields=["external-node-connectivity"]).values()
+        ) == {"true"}
 
     def _set_databag(
         self,

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -241,7 +241,6 @@ class RelationEndpoint:
             f"State of reconcile users {self._requested_users(event)=}, {self._shared_users=}"
         )
         for request in self._requested_users(event):
-            relation = request.relation
             if request not in self._shared_users:
                 request.create_database_and_user(
                     router_read_write_endpoint=router_read_write_endpoint,

--- a/src/relations/database_provides.py
+++ b/src/relations/database_provides.py
@@ -77,7 +77,14 @@ class _RelationThatRequestedUser(_Relation):
 
     @property
     def external_connectivity(self) -> bool:
-        """Whether any of the relations are marked as external."""
+        """Whether endpoints should be externally accessible
+
+        (e.g. when related to `data-integrator` charm)
+
+        Implements DA073 - Add Expose Flag to the Database Interface
+
+        https://docs.google.com/document/d/1Y7OZWwMdvF8eEMuVKrqEfuFV3JOjpqLHL7_GPqJpRHU
+        """
         return any(
             "true" in field.values()
             for field in self._interface.fetch_relation_data(
@@ -187,20 +194,14 @@ class RelationEndpoint:
         charm_.framework.observe(self._interface.on.database_requested, charm_.reconcile)
         charm_.framework.observe(charm_.on[self._NAME].relation_broken, charm_.reconcile)
 
-    @property
-    def external_connectivity(self) -> bool:
-        """Whether endpoints should be externally accessible
-
-        (e.g. when related to `data-integrator` charm)
-
-        Implements DA073 - Add Expose Flag to the Database Interface
-        """
+    def external_connectivity(self, event) -> bool:
+        """Whether any of the relations are marked as external."""
         requested_users = []
         for relation in self._interface.relations:
             try:
                 requested_users.append(
                     _RelationThatRequestedUser(
-                        relation=relation, interface=self._interface, event=None
+                        relation=relation, interface=self._interface, event=event
                     )
                 )
             except (

--- a/src/relations/tls.py
+++ b/src/relations/tls.py
@@ -113,6 +113,7 @@ class _Relation:
     def _generate_csr(self, key: bytes) -> bytes:
         """Generate certificate signing request (CSR)."""
         unit_name = self._charm.unit.name.replace("/", "-")
+        extra_hosts, extra_ips = self._charm.get_all_k8s_node_hostnames_and_ips()
         return tls_certificates.generate_csr(
             private_key=key,
             subject=socket.getfqdn(),
@@ -127,11 +128,13 @@ class _Relation:
                 f"{unit_name}.{self._charm.app.name}.{self._charm.model_service_domain}",
                 self._charm.app.name,
                 f"{self._charm.app.name}.{self._charm.model_service_domain}",
-            ],
+            ]
+            + extra_hosts,
             sans_ip=[
                 str(self._charm.model.get_binding("juju-info").network.bind_address),
                 "127.0.0.1",
-            ],
+            ]
+            + extra_ips,
         )
 
     def request_certificate_creation(self):

--- a/src/relations/tls.py
+++ b/src/relations/tls.py
@@ -128,13 +128,13 @@ class _Relation:
                 f"{unit_name}.{self._charm.app.name}.{self._charm.model_service_domain}",
                 self._charm.app.name,
                 f"{self._charm.app.name}.{self._charm.model_service_domain}",
+                *extra_hosts,
             ],
-            *extra_hosts,
             sans_ip=[
                 str(self._charm.model.get_binding("juju-info").network.bind_address),
                 "127.0.0.1",
+                *extra_ips,
             ],
-            *extra_ips,
         )
 
     def request_certificate_creation(self):

--- a/src/relations/tls.py
+++ b/src/relations/tls.py
@@ -128,13 +128,13 @@ class _Relation:
                 f"{unit_name}.{self._charm.app.name}.{self._charm.model_service_domain}",
                 self._charm.app.name,
                 f"{self._charm.app.name}.{self._charm.model_service_domain}",
-            ]
-            + extra_hosts,
+            ],
+            *extra_hosts,
             sans_ip=[
                 str(self._charm.model.get_binding("juju-info").network.bind_address),
                 "127.0.0.1",
-            ]
-            + extra_ips,
+            ],
+            *extra_ips,
         )
 
     def request_certificate_creation(self):

--- a/src/workload.py
+++ b/src/workload.py
@@ -37,10 +37,6 @@ class _NoQuorum(server_exceptions.Error):
         super().__init__(ops.WaitingStatus(self.MESSAGE))
 
 
-class WorkloadNotReadyError(Exception):
-    """Workload not ready"""
-
-
 class Workload:
     """MySQL Router workload"""
 

--- a/src/workload.py
+++ b/src/workload.py
@@ -37,6 +37,10 @@ class _NoQuorum(server_exceptions.Error):
         super().__init__(ops.WaitingStatus(self.MESSAGE))
 
 
+class WorkloadNotReadyError(Exception):
+    """Workload not ready"""
+
+
 class Workload:
     """MySQL Router workload"""
 

--- a/tests/integration/connector.py
+++ b/tests/integration/connector.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import mysql.connector
+
+
+class MySQLConnector:
+    """Context manager for mysql connector."""
+
+    def __init__(self, config: dict, commit: bool = True):
+        """Initialize the context manager.
+
+        Args:
+            config: Configuration dict for the mysql connector, like:
+                config = {
+                    "user": user,
+                    "password": remote_data["password"],
+                    "host": host,
+                    "database": database,
+                    "raise_on_warnings": False,
+                }
+            commit: Commit the transaction after the context is exited.
+        """
+        self.config = config
+        self.commit = commit
+
+    def __enter__(self):
+        """Create the connection and return a cursor."""
+        self.connection = mysql.connector.connect(**self.config)
+        self.cursor = self.connection.cursor()
+        return self.cursor
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Handle transaction and connection close."""
+        if self.commit:
+            self.connection.commit()
+        self.cursor.close()
+        self.connection.close()

--- a/tests/integration/juju_.py
+++ b/tests/integration/juju_.py
@@ -1,0 +1,8 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import importlib.metadata
+
+# libjuju version != juju agent version, but the major version should be identical—which is good
+_libjuju_version = importlib.metadata.version("juju")
+is_2_9 = int(_libjuju_version.split(".")[0]) < 3

--- a/tests/integration/juju_.py
+++ b/tests/integration/juju_.py
@@ -5,4 +5,8 @@ import importlib.metadata
 
 # libjuju version != juju agent version, but the major version should be identical—which is good
 _libjuju_version = importlib.metadata.version("juju")
-is_2_9 = int(_libjuju_version.split(".")[0]) < 3
+is_3_1_or_higher = (
+    len(_libjuju_version.split(".")) >= 2
+    and int(_libjuju_version.split(".")[0]) >= 3
+    and int(_libjuju_version.split(".")[1]) >= 1
+)

--- a/tests/integration/markers.py
+++ b/tests/integration/markers.py
@@ -5,7 +5,7 @@ import pytest
 
 from . import juju_
 
-is_3_1_or_higher = pytest.mark.skipif(
-    juju_.is_3_1_or_higher,
+skip_if_lower_than_3_1 = pytest.mark.skipif(
+    not juju_.is_3_1_or_higher,
     reason="Skips juju <3.1.x as we have a dependency for self-signed-certificates",
 )

--- a/tests/integration/markers.py
+++ b/tests/integration/markers.py
@@ -5,7 +5,7 @@ import pytest
 
 from . import juju_
 
-skip_juju_lower_than_3_1 = pytest.mark.skipif(
+is_3_1_or_higher = pytest.mark.skipif(
     juju_.is_3_1_or_higher,
     reason="Skips juju <3.1.x as we have a dependency for self-signed-certificates",
 )

--- a/tests/integration/markers.py
+++ b/tests/integration/markers.py
@@ -5,4 +5,7 @@ import pytest
 
 from . import juju_
 
-skip_juju_2_9 = pytest.mark.skipif(juju_.is_2_9, reason="Skips juju v2.9.x")
+skip_juju_lower_than_3_1 = pytest.mark.skipif(
+    juju_.is_3_1_or_higher,
+    reason="Skips juju <3.1.x as we have a dependency for self-signed-certificates",
+)

--- a/tests/integration/markers.py
+++ b/tests/integration/markers.py
@@ -1,0 +1,8 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+
+from . import juju_
+
+skip_juju_2_9 = pytest.mark.skipif(juju_.is_2_9, reason="Skips juju v2.9.x")

--- a/tests/integration/test_node_port.py
+++ b/tests/integration/test_node_port.py
@@ -36,7 +36,7 @@ MODEL_CONFIG = {"logging-config": "<root>=INFO;unit=DEBUG"}
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.skip_juju_lower_than_3_1
+@markers.is_3_1_or_higher
 async def test_build_and_deploy(ops_test: OpsTest):
     """Test the deployment of the charm."""
     # Build and deploy applications
@@ -127,7 +127,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.skip_juju_lower_than_3_1
+@markers.is_3_1_or_higher
 async def test_tls(ops_test: OpsTest):
     """Test the database relation."""
     logger.info("Assert TLS file exists")
@@ -157,7 +157,7 @@ async def test_tls(ops_test: OpsTest):
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.skip_juju_lower_than_3_1
+@markers.is_3_1_or_higher
 async def test_node_port_and_clusterip_setup():
     """Test the nodeport."""
     for app_name in [DATA_INTEGRATOR, APPLICATION_APP_NAME]:
@@ -188,7 +188,7 @@ async def test_node_port_and_clusterip_setup():
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.skip_juju_lower_than_3_1
+@markers.is_3_1_or_higher
 async def test_data_integrator(ops_test: OpsTest):
     """Test the nodeport."""
     application_app = ops_test.model.applications.get(APPLICATION_APP_NAME)

--- a/tests/integration/test_node_port.py
+++ b/tests/integration/test_node_port.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+from . import markers
+from .helpers import (
+    execute_queries_on_unit,
+    get_inserted_data_by_application,
+    get_server_config_credentials,
+    get_tls_ca,
+    get_unit_address,
+    is_connection_possible,
+)
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+MYSQL_APP_NAME = "mysql-k8s"
+MYSQL_ROUTER_APP_NAME = "mysql-router-k8s"
+SELF_SIGNED_CERTIFICATE_NAME = "self-signed-certificates"
+APPLICATION_APP_NAME = "mysql-test-app"
+DATA_INTEGRATOR = "data-integrator"
+SLOW_TIMEOUT = 15 * 60
+MODEL_CONFIG = {"logging-config": "<root>=INFO;unit=DEBUG"}
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+@markers.skip_juju_2_9
+async def test_build_and_deploy(ops_test: OpsTest):
+    """Test the deployment of the charm."""
+    # Build and deploy applications
+    mysqlrouter_charm = await ops_test.build_charm(".")
+    await ops_test.model.set_config(MODEL_CONFIG)
+
+    mysqlrouter_resources = {
+        "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
+    }
+
+    logger.info("Deploying mysql, mysqlrouter and application")
+    await asyncio.gather(
+        ops_test.model.deploy(
+            MYSQL_APP_NAME,
+            channel="8.0/edge",
+            application_name=MYSQL_APP_NAME,
+            config={"profile": "testing"},
+            series="jammy",
+            num_units=3,
+            trust=True,  # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
+        ),
+        ops_test.model.deploy(
+            mysqlrouter_charm,
+            application_name=MYSQL_ROUTER_APP_NAME,
+            series="jammy",
+            resources=mysqlrouter_resources,
+            num_units=1,
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            APPLICATION_APP_NAME,
+            channel="latest/edge",
+            application_name=APPLICATION_APP_NAME,
+            series="jammy",
+            num_units=1,
+        ),
+        ops_test.model.deploy(
+            DATA_INTEGRATOR,
+            channel="latest/edge",
+            application_name=DATA_INTEGRATOR,
+            series="jammy",
+            config={"database-name": "test"},
+            num_units=1,
+        ),
+        ops_test.model.deploy(
+            SELF_SIGNED_CERTIFICATE_NAME,
+            application_name=SELF_SIGNED_CERTIFICATE_NAME,
+            series="jammy",
+            num_units=1,
+        ),
+    )
+
+    async with ops_test.fast_forward():
+        logger.info("Relating mysql, mysqlrouter and application")
+        await ops_test.model.relate(
+            f"{MYSQL_APP_NAME}", f"{SELF_SIGNED_CERTIFICATE_NAME}:certificates"
+        ),
+        await ops_test.model.relate(
+            f"{MYSQL_ROUTER_APP_NAME}", f"{SELF_SIGNED_CERTIFICATE_NAME}:certificates"
+        ),
+
+        # Relate the database with mysqlrouter
+        await ops_test.model.relate(
+            f"{MYSQL_ROUTER_APP_NAME}:backend-database", f"{MYSQL_APP_NAME}:database"
+        )
+        # Relate mysqlrouter with data integrator
+        await ops_test.model.relate(
+            f"{DATA_INTEGRATOR}:mysql", f"{MYSQL_ROUTER_APP_NAME}:database"
+        )
+        # Relate mysqlrouter with application next
+        await ops_test.model.relate(
+            f"{APPLICATION_APP_NAME}:database", f"{MYSQL_ROUTER_APP_NAME}:database"
+        )
+
+        # Now, we should have one
+        await ops_test.model.wait_for_idle(
+            apps=[
+                MYSQL_APP_NAME,
+                MYSQL_ROUTER_APP_NAME,
+                APPLICATION_APP_NAME,
+                DATA_INTEGRATOR,
+                SELF_SIGNED_CERTIFICATE_NAME,
+            ],
+            status="active",
+            timeout=SLOW_TIMEOUT,
+        )
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+@markers.skip_juju_2_9
+async def test_tls(ops_test: OpsTest):
+    """Test the database relation."""
+    logger.info("Assert TLS file exists")
+    assert await get_tls_ca(
+        ops_test, MYSQL_ROUTER_APP_NAME + "/0"
+    ), "No CA found after TLS relation"
+
+    # After relating to only encrypted connection should be possible
+    logger.info("Asserting connections after relation")
+    unit = ops_test.model.units.get(DATA_INTEGRATOR + "/0")
+    action = await unit.run_action("get-credentials")
+    creds = (await asyncio.wait_for(action.wait(), 60)).results["mysql"]
+    config = {
+        "username": creds["username"],
+        "password": creds["password"],
+        "host": creds["endpoints"].split(":")[0],
+    }
+
+    extra_opts = {
+        "ssl_disabled": False,
+        "port": creds["endpoints"].split(":")[1],
+    }
+    assert is_connection_possible(
+        config, **extra_opts
+    ), f"Encryption enabled - connection not possible to unit {MYSQL_ROUTER_APP_NAME}/0"
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+@markers.skip_juju_2_9
+async def test_node_port_and_clusterip_setup():
+    """Test the nodeport."""
+    for app_name in [DATA_INTEGRATOR, APPLICATION_APP_NAME]:
+        try:
+            relation_info = yaml.safe_load(
+                subprocess.check_output(
+                    [
+                        "juju",
+                        "show-unit",
+                        f"{app_name}/0",
+                    ]
+                )
+            )[f"{app_name}/0"]["relation-info"]
+            if app_name == DATA_INTEGRATOR:
+                endpoint = list(filter(lambda x: x["endpoint"] == "mysql", relation_info))[0][
+                    "application-data"
+                ]["endpoints"]
+                assert "svc.cluster.local" not in endpoint
+            else:
+                endpoint = list(filter(lambda x: x["endpoint"] == "database", relation_info))[0][
+                    "application-data"
+                ]["endpoints"]
+                assert "svc.cluster.local" in endpoint
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to get the unit info for {app_name}: {e.output}")
+            raise
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+@markers.skip_juju_2_9
+async def test_data_integrator(ops_test: OpsTest):
+    """Test the nodeport."""
+    application_app = ops_test.model.applications.get(APPLICATION_APP_NAME)
+    mysql_app = ops_test.model.applications.get(MYSQL_APP_NAME)
+
+    # Ensure that the data inserted by sample application is present in the database
+    application_unit = application_app.units[0]
+    inserted_data = await get_inserted_data_by_application(application_unit)
+
+    mysql_unit = mysql_app.units[0]
+    mysql_unit_address = await get_unit_address(ops_test, mysql_unit.name)
+
+    server_config_credentials = await get_server_config_credentials(mysql_unit)
+
+    select_inserted_data_sql = [
+        f"SELECT data FROM continuous_writes_database.random_data WHERE data = '{inserted_data}'",
+    ]
+    selected_data = await execute_queries_on_unit(
+        mysql_unit_address,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+        select_inserted_data_sql,
+    )
+
+    assert len(selected_data) > 0
+    assert inserted_data == selected_data[0]

--- a/tests/integration/test_node_port.py
+++ b/tests/integration/test_node_port.py
@@ -36,7 +36,7 @@ MODEL_CONFIG = {"logging-config": "<root>=INFO;unit=DEBUG"}
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.skip_juju_2_9
+@markers.skip_juju_lower_than_3_1
 async def test_build_and_deploy(ops_test: OpsTest):
     """Test the deployment of the charm."""
     # Build and deploy applications
@@ -127,7 +127,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.skip_juju_2_9
+@markers.skip_juju_lower_than_3_1
 async def test_tls(ops_test: OpsTest):
     """Test the database relation."""
     logger.info("Assert TLS file exists")
@@ -157,7 +157,7 @@ async def test_tls(ops_test: OpsTest):
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.skip_juju_2_9
+@markers.skip_juju_lower_than_3_1
 async def test_node_port_and_clusterip_setup():
     """Test the nodeport."""
     for app_name in [DATA_INTEGRATOR, APPLICATION_APP_NAME]:
@@ -188,7 +188,7 @@ async def test_node_port_and_clusterip_setup():
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.skip_juju_2_9
+@markers.skip_juju_lower_than_3_1
 async def test_data_integrator(ops_test: OpsTest):
     """Test the nodeport."""
     application_app = ops_test.model.applications.get(APPLICATION_APP_NAME)

--- a/tests/integration/test_node_port.py
+++ b/tests/integration/test_node_port.py
@@ -36,7 +36,7 @@ MODEL_CONFIG = {"logging-config": "<root>=INFO;unit=DEBUG"}
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.is_3_1_or_higher
+@markers.skip_if_lower_than_3_1
 async def test_build_and_deploy(ops_test: OpsTest):
     """Test the deployment of the charm."""
     # Build and deploy applications
@@ -127,7 +127,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.is_3_1_or_higher
+@markers.skip_if_lower_than_3_1
 async def test_tls(ops_test: OpsTest):
     """Test the database relation."""
     logger.info("Assert TLS file exists")
@@ -157,7 +157,7 @@ async def test_tls(ops_test: OpsTest):
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.is_3_1_or_higher
+@markers.skip_if_lower_than_3_1
 async def test_node_port_and_clusterip_setup():
     """Test the nodeport."""
     for app_name in [DATA_INTEGRATOR, APPLICATION_APP_NAME]:
@@ -188,7 +188,7 @@ async def test_node_port_and_clusterip_setup():
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@markers.is_3_1_or_higher
+@markers.skip_if_lower_than_3_1
 async def test_data_integrator(ops_test: OpsTest):
     """Test the nodeport."""
     application_app = ops_test.model.applications.get(APPLICATION_APP_NAME)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from unittest.mock import Mock
+
 import pytest
 
 
@@ -52,7 +54,7 @@ def kubernetes_patch(monkeypatch):
     monkeypatch.setattr("rock._Path.unlink", lambda *args, **kwargs: None)
     monkeypatch.setattr("rock._Path.mkdir", lambda *args, **kwargs: None)
     monkeypatch.setattr("rock._Path.rmtree", lambda *args, **kwargs: None)
-    monkeypatch.setattr("lightkube.Client", lambda *args, **kwargs: None)
+    monkeypatch.setattr("lightkube.Client", lambda *args, **kwargs: Mock())
     monkeypatch.setattr("kubernetes_upgrade._Partition.get", lambda *args, **kwargs: 0)
     monkeypatch.setattr("kubernetes_upgrade._Partition.set", lambda *args, **kwargs: None)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -68,7 +68,7 @@ def kubernetes_patch(monkeypatch):
         lambda *args, **kwargs: None,
     )
     monkeypatch.setattr(
-        "kubernetes_charm.KubernetesRouterCharm.node_port", lambda *args, **kwargs: None
+        "kubernetes_charm.KubernetesRouterCharm._node_port", lambda *args, **kwargs: None
     )
     monkeypatch.setattr("kubernetes_upgrade._Partition.get", lambda *args, **kwargs: 0)
     monkeypatch.setattr("kubernetes_upgrade._Partition.set", lambda *args, **kwargs: None)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -56,13 +56,8 @@ def kubernetes_patch(monkeypatch):
     monkeypatch.setattr(
         "kubernetes_charm.KubernetesRouterCharm._patch_service", lambda *args, **kwargs: None
     )
-    monkeypatch.setattr(
-        "kubernetes_charm.KubernetesRouterCharm._node_ip", lambda *args, **kwargs: None
-    )
-    monkeypatch.setattr(
-        "kubernetes_charm.KubernetesRouterCharm._get_node_name",
-        lambda *args, **kwargs: None,
-    )
+    monkeypatch.setattr("kubernetes_charm.KubernetesRouterCharm._node_ip", None)
+    monkeypatch.setattr("kubernetes_charm.KubernetesRouterCharm._node_name", None)
     monkeypatch.setattr(
         "kubernetes_charm.KubernetesRouterCharm.get_all_k8s_node_hostnames_and_ips",
         lambda *args, **kwargs: None,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -60,10 +60,12 @@ def kubernetes_patch(monkeypatch):
         "kubernetes_charm.KubernetesRouterCharm.get_k8s_node_ip", lambda *args, **kwargs: None
     )
     monkeypatch.setattr(
-        "kubernetes_charm.KubernetesRouterCharm._get_node_name_for_pod", lambda *args, **kwargs: None
+        "kubernetes_charm.KubernetesRouterCharm._get_node_name_for_pod",
+        lambda *args, **kwargs: None,
     )
     monkeypatch.setattr(
-        "kubernetes_charm.KubernetesRouterCharm.get_all_k8s_node_hostnames_and_ips", lambda *args, **kwargs: None
+        "kubernetes_charm.KubernetesRouterCharm.get_all_k8s_node_hostnames_and_ips",
+        lambda *args, **kwargs: None,
     )
     monkeypatch.setattr(
         "kubernetes_charm.KubernetesRouterCharm.node_port", lambda *args, **kwargs: None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -57,10 +57,10 @@ def kubernetes_patch(monkeypatch):
         "kubernetes_charm.KubernetesRouterCharm._patch_service", lambda *args, **kwargs: None
     )
     monkeypatch.setattr(
-        "kubernetes_charm.KubernetesRouterCharm.get_k8s_node_ip", lambda *args, **kwargs: None
+        "kubernetes_charm.KubernetesRouterCharm._node_ip", lambda *args, **kwargs: None
     )
     monkeypatch.setattr(
-        "kubernetes_charm.KubernetesRouterCharm._get_node_name_for_pod",
+        "kubernetes_charm.KubernetesRouterCharm._get_node_name",
         lambda *args, **kwargs: None,
     )
     monkeypatch.setattr(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -59,6 +59,15 @@ def kubernetes_patch(monkeypatch):
     monkeypatch.setattr(
         "kubernetes_charm.KubernetesRouterCharm.get_k8s_node_ip", lambda *args, **kwargs: None
     )
+    monkeypatch.setattr(
+        "kubernetes_charm.KubernetesRouterCharm._get_node_name_for_pod", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "kubernetes_charm.KubernetesRouterCharm.get_all_k8s_node_hostnames_and_ips", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "kubernetes_charm.KubernetesRouterCharm.node_port", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr("kubernetes_upgrade._Partition.get", lambda *args, **kwargs: 0)
     monkeypatch.setattr("kubernetes_upgrade._Partition.set", lambda *args, **kwargs: None)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -56,6 +56,9 @@ def kubernetes_patch(monkeypatch):
     monkeypatch.setattr(
         "kubernetes_charm.KubernetesRouterCharm._patch_service", lambda *args, **kwargs: None
     )
+    monkeypatch.setattr(
+        "kubernetes_charm.KubernetesRouterCharm.get_k8s_node_ip", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr("kubernetes_upgrade._Partition.get", lambda *args, **kwargs: 0)
     monkeypatch.setattr("kubernetes_upgrade._Partition.set", lambda *args, **kwargs: None)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,8 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from unittest.mock import Mock
-
 import pytest
 
 
@@ -54,7 +52,10 @@ def kubernetes_patch(monkeypatch):
     monkeypatch.setattr("rock._Path.unlink", lambda *args, **kwargs: None)
     monkeypatch.setattr("rock._Path.mkdir", lambda *args, **kwargs: None)
     monkeypatch.setattr("rock._Path.rmtree", lambda *args, **kwargs: None)
-    monkeypatch.setattr("lightkube.Client", lambda *args, **kwargs: Mock())
+    monkeypatch.setattr("lightkube.Client", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "kubernetes_charm.KubernetesRouterCharm._patch_service", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr("kubernetes_upgrade._Partition.get", lambda *args, **kwargs: 0)
     monkeypatch.setattr("kubernetes_upgrade._Partition.set", lambda *args, **kwargs: None)
 


### PR DESCRIPTION
DPE-3771: In case mysql-router is connected with any app that sets `external-node-connectivity=true`, then NodePort must be configured and shared via relation. Applications that do not set it will receive the internal k8s DNS record instead. This way, an application, if running within the same k8s cluster, can choose to go through the internal cluster IPs and reduce its own latency.

An app outside of Juju ecosystem can connect with the database by relating the router with data-integrator, which triggers the creation of the NodePort. Then, the NodePort can be used to connect.

TLS is managed as well, in this change. If TLS and NodePort are both enabled, then the workers' IPs and hostnames where the routers are placed are captured and added as SANs to the certificate.