### PR TITLE
Remove build-wrapper from integration tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -81,12 +81,7 @@ set_env =
 pass_env =
     CI
     GITHUB_OUTPUT
-allowlist_externals =
-    {[testenv:build-wrapper]allowlist_externals}
 commands_pre =
     poetry install --only integration
-    {[testenv:build-wrapper]commands_pre}
 commands =
     poetry run pytest -v --tb native --log-cli-level=INFO -s --ignore={[vars]tests_path}/unit/ {posargs}
-commands_post =
-    {[testenv:build-wrapper]commands_post}


### PR DESCRIPTION
Needed when build happened in integration tests; no longer needed
