### PR TITLE
Mark test_exporter.py::test_exporter_endpoint as unstable

### DIFF
--- a/tests/integration/test_exporter.py
+++ b/tests/integration/test_exporter.py
@@ -26,6 +26,7 @@ SLOW_TIMEOUT = 25 * 60
 
 
 @pytest.mark.group(1)
+@pytest.mark.unstable
 @pytest.mark.abort_on_fail
 async def test_exporter_endpoint(ops_test: OpsTest) -> None:
     """Test that exporter endpoint is functional."""


### PR DESCRIPTION
Examples of test failing:
On release CI: https://github.com/canonical/mysql-router-k8s-operator/actions/runs/8781289085/job/24093311085
On PR CI: https://github.com/canonical/mysql-router-k8s-operator/actions/runs/8781217562/job/24093034929
