### PR TITLE
Remove lib-check prereq for running release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ jobs:
   release:
     name: Release charm
     needs:
-      - lib-check
       - ci-tests
       - build
     uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v13.1.0


### PR DESCRIPTION
## Issue
As part of [PR 237](https://github.com/canonical/mysql-router-k8s-operator/pull/237), the `lib-check` CI step was moved to run during pull request from release. However, the release still `needs` `lib-check` which no longer exists

## Solution
Remove the `lib-check` pre-req for release
