### PR TITLE
Add option for unit test coverage

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2271,4 +2271,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a1440a44f54c3048e0470d7bfa6d064eeff0e28d1ced77c2044eaac9696ea8c7"
+content-hash = "772a91cc48dc95356e8a2c1c9a95c4ccc018dd50bc20bb880bd1cfbb761a67a2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2271,4 +2271,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "f63cbcb42f293a5ef00117aa83d3c6d274f887ed20d6db2dca4f28461d6d9e6e"
+content-hash = "a1440a44f54c3048e0470d7bfa6d064eeff0e28d1ced77c2044eaac9696ea8c7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = []
 
 [tool.poetry.dependencies]
 python = "^3.10"
-ops = "<2.10.0"
+ops = "^2.6.0,<2.10.0"
 lightkube = "^0.14.0"
 tenacity = "^8.2.3"
 jinja2 = "^3.1.2"
@@ -19,7 +19,7 @@ requests = "^2.31.0"
 
 [tool.poetry.group.charm-libs.dependencies]
 # data_platform_libs/v0/data_interfaces.py
-ops = "^2.6.0,<2.10.0"
+ops = ">=2.0.0"
 # tls_certificates_interface/v1/tls_certificates.py
 cryptography = "*"
 jsonschema = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requests = "^2.31.0"
 
 [tool.poetry.group.charm-libs.dependencies]
 # data_platform_libs/v0/data_interfaces.py
-ops = "<2.10.0"
+ops = "^2.6.0,<2.10.0"
 # tls_certificates_interface/v1/tls_certificates.py
 cryptography = "*"
 jsonschema = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands_pre =
     poetry install --only main,charm-libs,unit
 commands =
     # `--numprocesses=120` workaround for extremely high memory usage (and out of memory crashes)
-    poetry run pytest --numprocesses=120 --ignore={[vars]tests_path}/integration/ {posargs}
+    poetry run pytest --numprocesses=120 --cov=src --ignore={[vars]tests_path}/integration/ {posargs}
 
 [testenv:integration]
 description = Run integration tests


### PR DESCRIPTION
## Issue
1. We are not defining a lower bound for the `ops` package
2. We are not generating a coverage report for unit tests

## Solution
1. Set `2.6.0` as the lower bound
2. Add option to generate coverage
