### PR TITLE
Fix/release ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   ci-tests:
-    needs:
     uses: ./.github/workflows/ci.yaml
     permissions:
       contents: write  # Needed for Allure Report beta

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,6 @@ on:
 jobs:
   ci-tests:
     needs:
-      - lib-check
     uses: ./.github/workflows/ci.yaml
     permissions:
       contents: write  # Needed for Allure Report beta


### PR DESCRIPTION
## Issue
Missed a `lib-check` requirement in release.yaml when working on https://github.com/canonical/mysql-router-k8s-operator/pull/239

## Solution
Remove unnecessary `lib-check` requirement
