### PR TITLE
Update gatekeeper revision

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Open PR with docs changes
-        uses: canonical/discourse-gatekeeper@stable
+        uses: canonical/discourse-gatekeeper@main
         id: docs-pr
         with:
           discourse_host: discourse.charmhub.io


### PR DESCRIPTION
Problem:

The stable branch is diverged from main the last half a year and some fixes on main looks like the problem we see in CI.

Solution:

Try to use `main`.