### PR TITLE
Reverting gatekeeper to main

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Open PR with docs changes
-        uses: canonical/discourse-gatekeeper@stable
+        uses: canonical/discourse-gatekeeper@main
         id: docs-pr
         with:
           discourse_host: discourse.charmhub.io


### PR DESCRIPTION
We are continue testing the gatekeeper to re-enable the documentation sync.