### PR TITLE
[DPE-4173] Stabilize exporter tests by using listen-port to avoid ephemeral ports

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -57,6 +57,6 @@ resources:
   mysql-router-image:
     type: oci-image
     description: OCI image for mysql-router
-    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:4a605458a09dc53feed91a0d81310dca267b2ac273ed7e1798bc4cb50c14fe68
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:89b8305613f6ce94f78a7c9b4baedef78f2816fd6bc74c00f6607bc5e57bd8e6
 assumes:
   - k8s-api

--- a/src/relations/cos.py
+++ b/src/relations/cos.py
@@ -34,7 +34,7 @@ class ExporterConfig:
 class COSRelation:
     """Relation with the cos bundle."""
 
-    _EXPORTER_PORT = "49152"
+    _EXPORTER_PORT = "49151"
     HTTP_SERVER_PORT = "8443"
     _METRICS_RELATION_NAME = "metrics-endpoint"
     _LOGGING_RELATION_NAME = "logging"

--- a/src/relations/cos.py
+++ b/src/relations/cos.py
@@ -29,12 +29,13 @@ class ExporterConfig:
     url: str
     username: str
     password: str
+    listen_port: str
 
 
 class COSRelation:
     """Relation with the cos bundle."""
 
-    _EXPORTER_PORT = "49151"
+    _EXPORTER_PORT = "9152"
     HTTP_SERVER_PORT = "8443"
     _METRICS_RELATION_NAME = "metrics-endpoint"
     _LOGGING_RELATION_NAME = "logging"
@@ -83,6 +84,7 @@ class COSRelation:
             url=f"https://127.0.0.1:{self.HTTP_SERVER_PORT}",
             username=self.MONITORING_USERNAME,
             password=self.get_monitoring_password(),
+            listen_port=self._EXPORTER_PORT,
         )
 
     @property

--- a/src/rock.py
+++ b/src/rock.py
@@ -161,6 +161,7 @@ class Rock(container.Container):
             startup = ops.pebble.ServiceStartup.ENABLED.value
 
             environment = {
+                "MYSQLROUTER_EXPORTER_LISTEN_PORT": config.listen_port,
                 "MYSQLROUTER_EXPORTER_USER": config.username,
                 "MYSQLROUTER_EXPORTER_PASS": config.password,
                 "MYSQLROUTER_EXPORTER_URL": config.url,

--- a/tests/integration/test_exporter.py
+++ b/tests/integration/test_exporter.py
@@ -109,7 +109,7 @@ async def test_exporter_endpoint(ops_test: OpsTest) -> None:
     unit_address = await get_unit_address(ops_test, unit.name)
 
     try:
-        requests.get(f"http://{unit_address}:49152/metrics", stream=False)
+        requests.get(f"http://{unit_address}:9152/metrics", stream=False)
     except requests.exceptions.ConnectionError as e:
         assert "[Errno 111] Connection refused" in str(e), "❌ expected connection refused error"
     else:
@@ -134,7 +134,7 @@ async def test_exporter_endpoint(ops_test: OpsTest) -> None:
         wait=tenacity.wait_fixed(10),
     ):
         with attempt:
-            response = requests.get(f"http://{unit_address}:49152/metrics", stream=False)
+            response = requests.get(f"http://{unit_address}:9152/metrics", stream=False)
             response.raise_for_status()
             assert (
                 "mysqlrouter_route_health" in response.text
@@ -153,7 +153,7 @@ async def test_exporter_endpoint(ops_test: OpsTest) -> None:
     ):
         with attempt:
             try:
-                requests.get(f"http://{unit_address}:49152/metrics", stream=False)
+                requests.get(f"http://{unit_address}:9152/metrics", stream=False)
             except requests.exceptions.ConnectionError as e:
                 assert "[Errno 111] Connection refused" in str(
                     e

--- a/tests/integration/test_exporter.py
+++ b/tests/integration/test_exporter.py
@@ -28,8 +28,7 @@ MYSQL_ROUTER_APP_NAME = MYSQL_ROUTER_DEFAULT_APP_NAME
 APPLICATION_APP_NAME = APPLICATION_DEFAULT_APP_NAME
 GRAFANA_AGENT_APP_NAME = "grafana-agent-k8s"
 SLOW_TIMEOUT = 25 * 60
-# TODO: reduce to < 5 * 60, after https://github.com/rluisr/mysqlrouter_exporter/issues/67 is resolved
-RETRY_TIMEOUT = 7 * 60
+RETRY_TIMEOUT = 3 * 60
 
 
 @pytest.mark.group(1)

--- a/tests/integration/test_exporter.py
+++ b/tests/integration/test_exporter.py
@@ -28,7 +28,8 @@ MYSQL_ROUTER_APP_NAME = MYSQL_ROUTER_DEFAULT_APP_NAME
 APPLICATION_APP_NAME = APPLICATION_DEFAULT_APP_NAME
 GRAFANA_AGENT_APP_NAME = "grafana-agent-k8s"
 SLOW_TIMEOUT = 25 * 60
-RETRY_TIMEOUT = 3 * 60
+# TODO: reduce to < 5 * 60, after https://github.com/rluisr/mysqlrouter_exporter/issues/67 is resolved
+RETRY_TIMEOUT = 7 * 60
 
 
 @pytest.mark.group(1)

--- a/tests/integration/test_exporter_with_tls.py
+++ b/tests/integration/test_exporter_with_tls.py
@@ -151,7 +151,7 @@ async def test_exporter_endpoint(ops_test: OpsTest) -> None:
     ):
         with attempt:
             try:
-                requests.get(f"http://{unit_address}:49152/metrics", stream=False)
+                requests.get(f"http://{unit_address}:9152/metrics", stream=False)
             except requests.exceptions.ConnectionError as e:
                 assert "[Errno 111] Connection refused" in str(
                     e
@@ -177,7 +177,7 @@ async def test_exporter_endpoint(ops_test: OpsTest) -> None:
         wait=tenacity.wait_fixed(10),
     ):
         with attempt:
-            response = requests.get(f"http://{unit_address}:49152/metrics", stream=False)
+            response = requests.get(f"http://{unit_address}:9152/metrics", stream=False)
             response.raise_for_status()
             assert (
                 "mysqlrouter_route_health" in response.text
@@ -212,7 +212,7 @@ async def test_exporter_endpoint(ops_test: OpsTest) -> None:
     ):
         with attempt:
             try:
-                requests.get(f"http://{unit_address}:49152/metrics", stream=False)
+                requests.get(f"http://{unit_address}:9152/metrics", stream=False)
             except requests.exceptions.ConnectionError as e:
                 assert "[Errno 111] Connection refused" in str(
                     e

--- a/tests/integration/test_exporter_with_tls.py
+++ b/tests/integration/test_exporter_with_tls.py
@@ -30,7 +30,8 @@ MYSQL_ROUTER_APP_NAME = MYSQL_ROUTER_DEFAULT_APP_NAME
 APPLICATION_APP_NAME = APPLICATION_DEFAULT_APP_NAME
 GRAFANA_AGENT_APP_NAME = "grafana-agent-k8s"
 SLOW_TIMEOUT = 25 * 60
-RETRY_TIMEOUT = 3 * 60
+# TODO: reduce to < 5 * 60, after https://github.com/rluisr/mysqlrouter_exporter/issues/67 is resolved
+RETRY_TIMEOUT = 7 * 60
 
 if juju_.is_3_or_higher:
     TLS_APP_NAME = "self-signed-certificates"

--- a/tests/integration/test_exporter_with_tls.py
+++ b/tests/integration/test_exporter_with_tls.py
@@ -30,8 +30,7 @@ MYSQL_ROUTER_APP_NAME = MYSQL_ROUTER_DEFAULT_APP_NAME
 APPLICATION_APP_NAME = APPLICATION_DEFAULT_APP_NAME
 GRAFANA_AGENT_APP_NAME = "grafana-agent-k8s"
 SLOW_TIMEOUT = 25 * 60
-# TODO: reduce to < 5 * 60, after https://github.com/rluisr/mysqlrouter_exporter/issues/67 is resolved
-RETRY_TIMEOUT = 7 * 60
+RETRY_TIMEOUT = 3 * 60
 
 if juju_.is_3_or_higher:
     TLS_APP_NAME = "self-signed-certificates"


### PR DESCRIPTION
## Issue
We are finding connections in `TIME_WAIT` between router exporter and mysql (still investigating what is happening here). Due to pebble's `on-failure: restart`, the exporter service eventually is able to start up when the connection in `TIME_WAIT` terminates after 60s - however, our retry in the test is 3 mins sometimes does not provide enough time for pebble's exponential backoff to work 

## Solution
Extend the timeout to 7 mins