### PR TITLE
Shorten integration test job name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v16.2.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v16.3.2
     with:
       cache: true
 
@@ -90,7 +90,7 @@ jobs:
       - lint
       - unit-test
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@integration-name
+    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v16.3.2
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
       architecture: ${{ matrix.architecture }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,14 +15,14 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v16.2.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v16.3.2
 
   release:
     name: Release charm
     needs:
       - ci-tests
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v16.2.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v16.3.2
     with:
       channel: 8.0/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/sync_issue_to_jira.yaml
+++ b/.github/workflows/sync_issue_to_jira.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   sync:
     name: Sync GitHub issue to Jira
-    uses: canonical/data-platform-workflows/.github/workflows/sync_issue_to_jira.yaml@v16.2.1
+    uses: canonical/data-platform-workflows/.github/workflows/sync_issue_to_jira.yaml@v16.3.2
     with:
       jira-base-url: https://warthogs.atlassian.net
       jira-project-key: DPE

--- a/poetry.lock
+++ b/poetry.lock
@@ -31,8 +31,8 @@ pytest = "*"
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v16.2.1"
-resolved_reference = "ddb4b5112daf309a5665e14caa5dfee03b96eae0"
+reference = "v16.3.2"
+resolved_reference = "bd73992bab4281c0d154807c7ce756a7bda4ac42"
 subdirectory = "python/pytest_plugins/allure_pytest_collection_report"
 
 [[package]]
@@ -1987,8 +1987,8 @@ pyyaml = "*"
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v16.2.1"
-resolved_reference = "ddb4b5112daf309a5665e14caa5dfee03b96eae0"
+reference = "v16.3.2"
+resolved_reference = "bd73992bab4281c0d154807c7ce756a7bda4ac42"
 subdirectory = "python/pytest_plugins/pytest_operator_cache"
 
 [[package]]
@@ -2006,8 +2006,8 @@ pytest = "*"
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v16.2.1"
-resolved_reference = "ddb4b5112daf309a5665e14caa5dfee03b96eae0"
+reference = "v16.3.2"
+resolved_reference = "bd73992bab4281c0d154807c7ce756a7bda4ac42"
 subdirectory = "python/pytest_plugins/pytest_operator_groups"
 
 [[package]]
@@ -2647,4 +2647,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "99e9413c0a035e01efcc859a315f133434fdf77d6e46d77bdc87cd06ca139d57"
+content-hash = "c705d18865abf01b63be83529dc93df2682f38a4d307d5e472f490172c557741"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,14 +63,14 @@ ops = "^2.9.0"
 [tool.poetry.group.integration.dependencies]
 pytest = "^8.2.2"
 pytest-operator = "^0.35.0"
-pytest-operator-cache = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.2.1", subdirectory = "python/pytest_plugins/pytest_operator_cache"}
-pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.2.1", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
+pytest-operator-cache = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.3.2", subdirectory = "python/pytest_plugins/pytest_operator_cache"}
+pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.3.2", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
 juju = "^3.2.2"
 mysql-connector-python = "~8.0.33"
 pyyaml = "^6.0.1"
 tenacity = "^8.5.0"
 allure-pytest = "^2.13.5"
-allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.2.1", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
+allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.3.2", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
 
 
 [tool.coverage.run]


### PR DESCRIPTION
So that matrix values (e.g. juju version, arch) can show without truncating in GitHub Actions UI sidebar
