### PR TITLE
Update sync_docs.yaml 

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v20.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v21.0.0
     with:
       reviewers: a-velasco,izmalk
     permissions:

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@download-discourse-topics
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v.19.1.0
     with:
       reviewers: canonical/data-platform-technical-authors,octocat
     permissions:

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -1,33 +1,18 @@
-name: Sync docs from Discourse
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Sync Discourse docs
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '53 0 * * *' # Daily at 00:53 UTC
-  push:
-    branches:
-      - main
+    - cron: '53 0 * * *'  # Daily at 00:53 UTC
 
 jobs:
   sync-docs:
-    name: Open PR with docs changes
-    runs-on: ubuntu-latest
+    name: Sync docs from Discourse
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@download-discourse-topics
+    with:
+      reviewers: a-velasco,octocat
     permissions:
-      contents: write  # Needed to login to Discourse
-      pull-requests: write # Need to create PR
-    steps:
-      - uses: actions/checkout@v4
-      - name: Open PR with docs changes
-        uses: canonical/discourse-gatekeeper@main
-        id: docs-pr
-        with:
-          discourse_host: discourse.charmhub.io
-          discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
-          discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dry_run: "true"
-
-      - name: Show migrate output
-        run: echo '${{ steps.docs-pr.outputs.migrate }}'
-      - name: Show reconcile output
-        run: echo '${{ steps.docs-pr.outputs.reconcile }}'
+      contents: write  # Needed to push branch & tag
+      pull-requests: write  # Needed to create PR

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v.19.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v19.1.0
     with:
       reviewers: canonical/data-platform-technical-authors,octocat
     permissions:

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Sync docs from Discourse
     uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v19.2.0
     with:
-      reviewers: canonical/data-platform-technical-authors
+      reviewers: a-velasco,izmalk
     permissions:
       contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Sync docs from Discourse
     uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@download-discourse-topics
     with:
-      reviewers: a-velasco,octocat
+      reviewers: canonical/data-platform-technical-authors,octocat
     permissions:
       contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Sync docs from Discourse
     uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v19.2.0
     with:
-      reviewers: canonical/data-platform-technical-authors,octocat
+      reviewers: canonical/data-platform-technical-authors
     permissions:
       contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v.19.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v.19.0.0
     with:
       reviewers: canonical/data-platform-technical-authors,octocat
     permissions:

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v19.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v19.2.0
     with:
       reviewers: canonical/data-platform-technical-authors,octocat
     permissions:

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v19.2.0
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v20.0.1
     with:
       reviewers: a-velasco,izmalk
     permissions:


### PR DESCRIPTION
This PR changes the `sync_docs.yaml` workflow to the [new version with a different backend](https://github.com/canonical/data-platform-workflows/pull/220#issue-2449415094).