### PR TITLE
Move poetry export inside the charm build

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 type: charm
@@ -10,23 +10,27 @@ bases:
     channel: "22.04"
     architectures: [arm64]
 parts:
-  charm:
-    override-pull: |
-      craftctl default
-      if [[ ! -f requirements.txt ]]
-      then
-          echo 'ERROR: Use "tox run -e build-dev" instead of calling "charmcraft pack" directly' >&2
-          exit 1
-      fi
-    charm-strict-dependencies: true
-    charm-entrypoint: src/kubernetes_charm.py
-    prime:
+  charm-files:
+    # Extra files this charm uses.
+    plugin: dump
+    source: .
+    stage:
       - charm_version
       - workload_version
       - scripts
+  charm:
+    override-pull: |
+      craftctl default
+      pipx install poetry~=1.8
+      $HOME/.local/bin/poetry export --only main,charm-libs --output requirements.txt
+    charm-strict-dependencies: true
+    charm-entrypoint: src/kubernetes_charm.py
+    charm-requirements:
+      - requirements.txt
     build-packages:
       - libffi-dev
       - libssl-dev
       - pkg-config
       - rustc
       - cargo
+      - pipx

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,6 @@ commands_pre =
     # (https://docs.google.com/document/d/1Jv1jhWLl8ejK3iJn7Q3VbCIM9GIhp8926bgXpdtx-Sg/edit?pli=1)
     # is pending review.
     python -c 'import pathlib; import shutil; import subprocess; git_hash=subprocess.run(["git", "describe", "--always", "--dirty"], capture_output=True, check=True, encoding="utf-8").stdout; file = pathlib.Path("charm_version"); shutil.copy(file, pathlib.Path("charm_version.backup")); version = file.read_text().strip(); file.write_text(f"{version}+{git_hash}")'
-
-    poetry export --only main,charm-libs --output requirements.txt
 commands =
     build-production: charmcraft pack {posargs}
     build-dev: charmcraftcache pack {posargs}


### PR DESCRIPTION
This demonstrates using `poetry export` inside the build of the charm, allowing the user to `git clone` and then `charmcraft pack`.

It also:

- Uses the dump plugin to add extra primed files
- Adds an explicit requirements file (see: https://github.com/canonical/charmcraft/issues/1389)

## Issue


## Solution
