### PR TITLE
[DPE-5711] Add warnings to destructive actions

### DIFF
--- a/src/kubernetes_upgrade.py
+++ b/src/kubernetes_upgrade.py
@@ -232,10 +232,12 @@ class Upgrade(upgrade.Upgrade):
                 # also applicable `if not force`, but is unlikely to happen since all units are
                 # healthy `if not force`.
                 message = f"Attempting to upgrade unit {self._partition}"
+                action_event.set_results({"result": message})
+                logger.warning(f"Resume upgrade event succeeded: {message}")
             else:
                 message = f"Upgrade resumed. Unit {self._partition} is upgrading next"
-            action_event.set_results({"result": message})
-            logger.debug(f"Resume upgrade event succeeded: {message}")
+                action_event.set_results({"result": message})
+                logger.debug(f"Resume upgrade event succeeded: {message}")
 
     @property
     def authorized(self) -> bool:

--- a/src/kubernetes_upgrade.py
+++ b/src/kubernetes_upgrade.py
@@ -222,6 +222,7 @@ class Upgrade(upgrade.Upgrade):
                 action_event.fail(message)
                 return
             if force:
+                logger.warning(f"Resume upgrade action ran with {force=}")
                 # If a unit was unhealthy and the upgrade was forced, only the next unit will
                 # upgrade. As long as 1 or more units are unhealthy, the upgrade will need to be
                 # forced for each unit.
@@ -232,12 +233,10 @@ class Upgrade(upgrade.Upgrade):
                 # also applicable `if not force`, but is unlikely to happen since all units are
                 # healthy `if not force`.
                 message = f"Attempting to upgrade unit {self._partition}"
-                action_event.set_results({"result": message})
-                logger.warning(f"Resume upgrade event succeeded: {message}")
             else:
                 message = f"Upgrade resumed. Unit {self._partition} is upgrading next"
-                action_event.set_results({"result": message})
-                logger.debug(f"Resume upgrade event succeeded: {message}")
+            action_event.set_results({"result": message})
+            logger.debug(f"Resume upgrade event succeeded: {message}")
 
     @property
     def authorized(self) -> bool:

--- a/src/workload.py
+++ b/src/workload.py
@@ -327,7 +327,7 @@ class AuthenticatedWorkload(Workload):
 
     def _enable_router(self, *, event, tls: bool, unit_name: str) -> None:
         """Enable router after setting up all the necessary prerequisites."""
-        logger.debug("Enabling MySQL Router service")
+        logger.info("Enabling MySQL Router service")
         self._cleanup_after_upgrade_or_potential_container_restart()
         # create an empty credentials file, if the file does not exist
         self._container.create_router_rest_api_credentials_file()
@@ -337,7 +337,7 @@ class AuthenticatedWorkload(Workload):
         )
         self._container.update_mysql_router_service(enabled=True, tls=tls)
         self._logrotate.enable()
-        logger.debug("Enabled MySQL Router service")
+        logger.info("Enabled MySQL Router service")
         self._charm.wait_until_mysql_router_ready(event=event)
 
     def _enable_exporter(

--- a/src/workload.py
+++ b/src/workload.py
@@ -145,14 +145,14 @@ class Workload:
 
     def _disable_router(self) -> None:
         """Disable router and clean up corresponding router files."""
-        logger.debug("Disabling MySQL Router service")
+        logger.info("Disabling MySQL Router service")
         self._container.update_mysql_router_service(enabled=False)
         self._logrotate.disable()
         self._container.router_config_directory.rmtree()
         self._container.router_config_directory.mkdir()
         self._router_data_directory.rmtree()
         self._router_data_directory.mkdir()
-        logger.debug("Disabled MySQL Router service")
+        logger.info("Disabled MySQL Router service")
 
     def reconcile(
         self,


### PR DESCRIPTION
This PR adds warning level messages when a _destructive_ action is performed. The definition of _destructive_ seems to be associated with data loss, which I think it can only happen, from user action, whenever they force a primary failover without checking considering the health of such instance.

### Additional info
- Paulo confirmed that this ticket was created to familiarised myself with the codebases.
- Alex referenced this PostgreSQL operator [PR](https://github.com/canonical/postgresql-k8s-operator/pull/753) as the reason behind the need for warnings.