### PR TITLE
Minor adjustments while standarding shared code with the router vm charm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.1.1
     with:
       cache: true
 
@@ -96,7 +96,7 @@ jobs:
       - lint
       - unit-test
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v23.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v23.1.1
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
       architecture: ${{ matrix.architecture }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,14 +15,14 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.1.1
 
   release:
     name: Release charm
     needs:
       - ci-tests
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v23.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v23.1.1
     with:
       channel: 8.0/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v23.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v23.1.1
     with:
       reviewers: a-velasco,izmalk
     permissions:

--- a/src/abstract_charm.py
+++ b/src/abstract_charm.py
@@ -110,7 +110,7 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def _exposed_read_write_endpoint(self) -> typing.Optional[str]:
+    def _exposed_read_write_endpoints(self) -> typing.Optional[str]:
         """The exposed read-write endpoint.
 
         Only defined in vm charm.
@@ -118,7 +118,7 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def _exposed_read_only_endpoint(self) -> typing.Optional[str]:
+    def _exposed_read_only_endpoints(self) -> typing.Optional[str]:
         """The exposed read-only endpoint.
 
         Only defined in vm charm.
@@ -134,10 +134,7 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
     @property
     @abc.abstractmethod
     def _status(self) -> ops.StatusBase:
-        """Status of the charm.
-
-        Only applies to Kubernetes charm
-        """
+        """Status of the charm."""
 
     @property
     def _tls_certificate_saved(self) -> bool:
@@ -258,13 +255,6 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
         Only applies to Kubernetes charm
         """
 
-    def _check_service_connectivity(self) -> bool:
-        """Check if the service is available (connectable with a socket).
-
-        Returns false if Machine charm. Overridden in Kubernetes charm.
-        """
-        return False
-
     @abc.abstractmethod
     def _reconcile_ports(self, *, event) -> None:
         """Reconcile exposed ports.
@@ -364,8 +354,8 @@ class MySQLRouterCharm(ops.CharmBase, abc.ABC):
                         event=event,
                         router_read_write_endpoints=self._read_write_endpoints,
                         router_read_only_endpoints=self._read_only_endpoints,
-                        exposed_read_write_endpoint=self._exposed_read_write_endpoint,
-                        exposed_read_only_endpoint=self._exposed_read_only_endpoint,
+                        exposed_read_write_endpoints=self._exposed_read_write_endpoints,
+                        exposed_read_only_endpoints=self._exposed_read_only_endpoints,
                         shell=workload_.shell,
                     )
                     self._update_endpoints()

--- a/src/kubernetes_charm.py
+++ b/src/kubernetes_charm.py
@@ -126,7 +126,7 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
                 return ops.BlockedStatus("K8s service not connectible")
 
     def is_externally_accessible(self, *, event) -> typing.Optional[bool]:
-        """No-op since this charm is exposed with node-port"""
+        """No-op since this charm is exposed with the expose-external config."""
 
     def _get_service(self) -> typing.Optional[lightkube.resources.core_v1.Service]:
         """Get the managed k8s service."""
@@ -251,6 +251,7 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
         logger.info(f"Request to create desired service {desired_service_type=} dispatched")
 
     def _check_service_connectivity(self) -> bool:
+        """Check if the service is available (connectable with a socket)."""
         if not self._get_service() or not isinstance(
             self.get_workload(event=None), workload.AuthenticatedWorkload
         ):
@@ -402,12 +403,12 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
         return self._get_hosts_ports("ro")
 
     @property
-    def _exposed_read_write_endpoint(self) -> typing.Optional[str]:
+    def _exposed_read_write_endpoints(self) -> typing.Optional[str]:
         """Only applies to VM charm, so no-op."""
         pass
 
     @property
-    def _exposed_read_only_endpoint(self) -> typing.Optional[str]:
+    def _exposed_read_only_endpoints(self) -> typing.Optional[str]:
         """Only applies to VM charm, so no-op."""
         pass
 


### PR DESCRIPTION
## Issue
While standardizing code in the router vm charm (https://github.com/canonical/mysql-router-operator/pull/182), there were small minor adjustments that needed to be made in the code in this repo

## Solution
Propagate appropriate changes