### PR TITLE
[DPE-6042] Make tox commands resilient to white-space paths

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,14 @@ no_package = True
 env_list = lint, unit
 
 [vars]
-src_path = {tox_root}/src
-tests_path = {tox_root}/tests
-scripts_path = {tox_root}/scripts
+src_path = "{tox_root}/src"
+tests_path = "{tox_root}/tests"
+scripts_path = "{tox_root}/scripts"
 all_path = {[vars]src_path} {[vars]tests_path} {[vars]scripts_path}
 
 [testenv]
 set_env =
-    PYTHONPATH = {[vars]src_path}:{tox_root}/lib
+    PYTHONPATH = {tox_root}/src:{tox_root}/lib
     PY_COLORS = 1
 allowlist_externals =
     poetry


### PR DESCRIPTION
This PR fixes [tox.ini](https://github.com/canonical/mysql-router-k8s-operator/blob/main/tox.ini) commands when the repository is cloned on a white-space containing path.

### How to reproduce:
```shell
$ mkdir -p "Projects/Canonical/Data Platform/MySQL"
$ cd "Projects/Canonical/Data Platform/MySQL"
$ git clone https://github.com/canonical/mysql-router-k8s-operator
$ cd mysql-router-k8s-operator
$ tox run -e format
> ...
> /Users/<USERNAME>/Projects/Canonical/Data:1:1: E902 No such file or directory (os error 2)
> Platform/MySQL/mysql-router-k8s-operator/src:1:1: E902 No such file or directory (os error 2)
> Platform/MySQL/mysql-router-k8s-operator/tests:1:1: E902 No such file or directory (os error 2)

```

### Additional considerations
Using the quoted paths to set up the `PYTHONPATH` does not work. This can be tested by running the unit tests.