### PR TITLE
[DPE-5588] Check against invalid arch

### DIFF
--- a/src/architecture.py
+++ b/src/architecture.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Architecture utilities module"""
+
+import logging
+import os
+import pathlib
+import platform
+
+import yaml
+from ops.charm import CharmBase
+from ops.model import BlockedStatus
+
+logger = logging.getLogger(__name__)
+
+
+class WrongArchitectureWarningCharm(CharmBase):
+    """A fake charm class that only signals a wrong architecture deploy."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        hw_arch = platform.machine()
+        self.unit.status = BlockedStatus(
+            f"Charm incompatible with {hw_arch} architecture. "
+            f"If this app is being refreshed, rollback"
+        )
+        raise RuntimeError(
+            f"Incompatible architecture: this charm revision does not support {hw_arch}. "
+            f"If this app is being refreshed, rollback with instructions from Charmhub docs. "
+            f"If this app is being deployed for the first time, remove it and deploy it again "
+            f"using a compatible revision."
+        )
+
+
+def is_wrong_architecture() -> bool:
+    """Checks if charm was deployed on wrong architecture."""
+    charm_path = os.environ.get("CHARM_DIR", "")
+    manifest_path = pathlib.Path(charm_path, "manifest.yaml")
+
+    if not manifest_path.exists():
+        logger.error("Cannot check architecture: manifest file not found in %s", manifest_path)
+        return False
+
+    manifest = yaml.safe_load(manifest_path.read_text())
+
+    manifest_archs = []
+    for base in manifest["bases"]:
+        base_archs = base.get("architectures", [])
+        manifest_archs.extend(base_archs)
+
+    hardware_arch = platform.machine()
+    if ("amd64" in manifest_archs and hardware_arch == "x86_64") or (
+        "arm64" in manifest_archs and hardware_arch == "aarch64"
+    ):
+        logger.debug("Charm architecture matches")
+        return False
+
+    logger.error("Charm architecture does not match")
+    return True

--- a/src/kubernetes_charm.py
+++ b/src/kubernetes_charm.py
@@ -6,6 +6,13 @@
 
 """MySQL Router Kubernetes charm"""
 
+import ops
+
+from architecture import WrongArchitectureWarningCharm, is_wrong_architecture
+
+if is_wrong_architecture() and __name__ == "__main__":
+    ops.main.main(WrongArchitectureWarningCharm)
+
 import enum
 import functools
 import json

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -7,7 +7,8 @@ import logging
 import pathlib
 import subprocess
 import tempfile
-from typing import Dict, List, Optional
+from pathlib import Path
+from typing import Dict, List, Optional, Union
 
 import mysql.connector
 import tenacity
@@ -655,3 +656,17 @@ def get_juju_status(model_name: str) -> str:
         model_name: The model for which to retrieve juju status for
     """
     return subprocess.check_output(["juju", "status", "--model", model_name]).decode("utf-8")
+
+
+async def get_charm(charm_path: Union[str, Path], architecture: str, bases_index: int) -> Path:
+    """Fetches packed charm from CI runner without checking for architecture."""
+    charm_path = Path(charm_path)
+    charmcraft_yaml = yaml.safe_load((charm_path / "charmcraft.yaml").read_text())
+    assert charmcraft_yaml["type"] == "charm"
+
+    base = charmcraft_yaml["bases"][bases_index]
+    build_on = base.get("build-on", [base])[0]
+    version = build_on["channel"]
+    packed_charms = list(charm_path.glob(f"*{version}-{architecture}.charm"))
+
+    return packed_charms[0].resolve(strict=True)

--- a/tests/integration/test_architecture.py
+++ b/tests/integration/test_architecture.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from . import markers
+from .helpers import get_charm
+
+MYSQL_ROUTER_APP_NAME = "mysql-router-k8s"
+
+
+@pytest.mark.group(1)
+@markers.amd64_only
+async def test_arm_charm_on_amd_host(ops_test: OpsTest) -> None:
+    """Tries deploying an arm64 charm on amd64 host."""
+    charm = await get_charm(".", "arm64", 1)
+
+    await ops_test.model.deploy(
+        charm,
+        application_name=MYSQL_ROUTER_APP_NAME,
+        num_units=1,
+        config={"profile": "testing"},
+        base="ubuntu@22.04",
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[MYSQL_ROUTER_APP_NAME],
+        status="error",
+        raise_on_error=False,
+    )
+
+
+@pytest.mark.group(1)
+@markers.arm64_only
+async def test_amd_charm_on_arm_host(ops_test: OpsTest) -> None:
+    """Tries deploying an amd64 charm on arm64 host."""
+    charm = await get_charm(".", "amd64", 0)
+
+    await ops_test.model.deploy(
+        charm,
+        application_name=MYSQL_ROUTER_APP_NAME,
+        num_units=1,
+        config={"profile": "testing"},
+        base="ubuntu@22.04",
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[MYSQL_ROUTER_APP_NAME],
+        status="error",
+        raise_on_error=False,
+    )

--- a/tests/unit/test_architecture.py
+++ b/tests/unit/test_architecture.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import patch
+
+from architecture import is_wrong_architecture
+
+TEST_MANIFEST = """
+    bases:
+        - architectures:
+            - {arch}
+          channel: '22.04'
+          name: ubuntu
+"""
+
+
+def test_wrong_architecture_file_not_found():
+    """Tests if the function returns False when the charm file doesn't exist."""
+    with (
+        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
+        patch("pathlib.Path.exists", return_value=False),
+    ):
+        assert not is_wrong_architecture()
+
+
+def test_wrong_architecture_amd64():
+    """Tests if the function correctly identifies arch when charm is AMD."""
+    with (
+        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.read_text", return_value=TEST_MANIFEST.format(arch="amd64")),
+        patch("platform.machine") as machine,
+    ):
+        machine.return_value = "x86_64"
+        assert not is_wrong_architecture()
+        machine.return_value = "aarch64"
+        assert is_wrong_architecture()
+
+
+def test_wrong_architecture_arm64():
+    """Tests if the function correctly identifies arch when charm is ARM."""
+    with (
+        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.read_text", return_value=TEST_MANIFEST.format(arch="arm64")),
+        patch("platform.machine") as machine,
+    ):
+        machine.return_value = "x86_64"
+        assert is_wrong_architecture()
+        machine.return_value = "aarch64"
+        assert not is_wrong_architecture()


### PR DESCRIPTION
This PR introduces the usage of the newly created architecture module, similar to the one in the MySQL lib (see [code](https://github.com/canonical/mysql-operator/blob/main/lib/charms/mysql/v0/architecture.py)).

The shape of the integration tests, as well as the helper used to get the built charm in the architecture that mismatches the one of the host itself, have been adapted from the one Lucas created for PostgreSQL-k8s (see [code](https://github.com/canonical/postgresql-k8s-operator/blob/70a96ce33eb0de054b9297e3bd558f6ece54c0b0/tests/integration/test_wrong_arch.py)).

### Additional info

- The new logic has been added as a module, and not as a charm lib, due to @carlcsaposs-canonical preference.