### PR TITLE
[DPE-6447] Avoid storing passwords on disk when running mysqlsh

### DIFF
--- a/src/container.py
+++ b/src/container.py
@@ -196,14 +196,20 @@ class Container(abc.ABC):
         return self._run_command(args, timeout=timeout)
 
     # TODO python3.10 min version: Use `list` instead of `typing.List`
-    def run_mysql_shell(self, args: typing.List[str], *, timeout: int = None) -> str:
+    def run_mysql_shell(
+        self,
+        args: typing.List[str],
+        *,
+        timeout: int = None,
+        input: str = None,  # noqa: A002 Match subprocess.run()
+    ) -> str:
         """Run MySQL Shell command.
 
         Raises:
             CalledProcessError: Command returns non-zero exit code
         """
         args.insert(0, self._mysql_shell_command)
-        return self._run_command(args, timeout=timeout)
+        return self._run_command(args, timeout=timeout, input=input)
 
     @abc.abstractmethod
     def path(self, *args) -> Path:

--- a/src/mysql_shell/templates/try_except_wrapper.py.jinja
+++ b/src/mysql_shell/templates/try_except_wrapper.py.jinja
@@ -3,7 +3,8 @@ import mysqlsh
 import traceback
 
 try:
-    shell.connect("{{ username }}:{{ password }}@{{ host }}:{{ port }}")
+    # Disable wizards in this script, since it will be invoked without --no-wizard
+    shell.options.set('useWizards', False)
     {{ code|indent(width=4) }}
 except mysqlsh.DBError as exception:
     error = {


### PR DESCRIPTION
## Issue
We are storing passwords on disk (in the mysqlsh python script) when we execute mysqlsh. This is a security vulnerability

## Solution
Avoid writing passwords on disk, and instead use --passwords-from-stdin flag of mysqlsh