### PR TITLE
[MISC] Update data-integrator charm base

### DIFF
--- a/tests/integration/test_expose_external.py
+++ b/tests/integration/test_expose_external.py
@@ -132,7 +132,7 @@ async def test_expose_external(ops_test, charm) -> None:
             DATA_INTEGRATOR,
             channel="latest/edge",
             application_name=DATA_INTEGRATOR,
-            base="ubuntu@22.04",
+            base="ubuntu@24.04",
             config={"database-name": TEST_DATABASE_NAME},
             num_units=1,
         ),


### PR DESCRIPTION
This PR bumps the charm base for the `data-integrator` charm, which was updated on [this PR](https://github.com/canonical/data-integrator/pull/132) back in April 9th.