### PR TITLE
feature: DPE-7534 use absolute fqdn and bigger ttl

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -319,7 +319,7 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
     def _host(self) -> str:
         """K8s service hostname for MySQL Router"""
         # Example: mysql-router-k8s-service.my-model.svc.cluster.local
-        return f"{self.service_name}.{self.model_service_domain}"
+        return f"{self.service_name}.{self.model_service_domain}."
 
     def _get_node_hosts(self) -> set[str]:
         """Return the node ports of nodes where units of this app are scheduled."""

--- a/src/workload.py
+++ b/src/workload.py
@@ -252,6 +252,8 @@ class AuthenticatedWorkload(Workload):
             "--conf-set-option",
             f"http_auth_backend:default_auth_backend.filename={self._container.rest_api_credentials_file.relative_to_container}",
             "--conf-use-gr-notifications",
+            "--conf-set-option",
+            "metadata_cache:bootstrap.ttl=60",
             # destination_status added to workaround MySQL Router bug
             # https://bugs.mysql.com/bug.php?id=118059
             # TODO: Remove once fixed on upstream


### PR DESCRIPTION
## Issue

See issues #443 and #444

Also, mysql-router configure `ttl=5` [seconds] whenever clusterset is configured, independently of the usage of `gr_notifications`.
For comparison, without `gr_notifications` default is `ttl=0.5`, so this is a conservative change giving geographical concerns when having multiple clusters.
Given we are using `gr_notifications`, it's safe to override to a greater value, since this is a fallback mechanism.

## Solution

- use and propagate absolute fqdn (trailing dot) internally and to consumers
- set `60s` as default metadata_cache refresh interval

For test bundle (3 router, 3 server, 1 test-app), this changes (+ usage of absolute fqdn on server) took coredns requests from 2.18 kp/s to 0.270kp/s.

![requests_k8s](https://github.com/user-attachments/assets/db1d27bd-8b68-4a77-99b4-94fcb4446071)

Fixes #443 #444
