### PR TITLE
[MISC] Pin grafana-agent-k8s channel to `1/stable`

### DIFF
--- a/tests/integration/test_exporter.py
+++ b/tests/integration/test_exporter.py
@@ -73,7 +73,7 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
             application_name=GRAFANA_AGENT_APP_NAME,
             num_units=1,
             base="ubuntu@22.04",
-            channel="latest/stable",
+            channel="1/stable",
         ),
     )
 

--- a/tests/integration/test_exporter_with_tls.py
+++ b/tests/integration/test_exporter_with_tls.py
@@ -89,7 +89,7 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
             application_name=GRAFANA_AGENT_APP_NAME,
             num_units=1,
             base="ubuntu@22.04",
-            channel="latest/stable",
+            channel="1/stable",
         ),
     )
 


### PR DESCRIPTION
The Observability team removed the `latest/stable` track as of Friday June 20. Channels will now be prefixed by the charm major versions (i.e. `1/...`, `2/...`). See:

- June 20th: Last [CI run](https://github.com/canonical/mysql-router-k8s-operator/actions/runs/15769147782) where exporter integration tests passed.
- June 21th: First [CI run](https://github.com/canonical/mysql-router-k8s-operator/actions/runs/15790613923) where exporter integration tests failed.