### PR TITLE
Add optional flags to provides endpoints

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,7 +24,6 @@ containers:
 provides:
   database:
     interface: mysql_client
-    optional: true
   metrics-endpoint:
     interface: prometheus_scrape
     optional: true

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,10 +24,13 @@ containers:
 provides:
   database:
     interface: mysql_client
+    optional: true
   metrics-endpoint:
     interface: prometheus_scrape
+    optional: true
   grafana-dashboard:
     interface: grafana_dashboard
+    optional: true
 requires:
   backend-database:
     interface: mysql_client

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -37,6 +37,7 @@ requires:
   certificates:
     interface: tls-certificates
     limit: 1
+    optional: true
   logging:
     interface: loki_push_api
     limit: 1


### PR DESCRIPTION
## Issue

Since provides endpoints can be non-optional, can the default value of `optional` is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional), these endpoints are assumed non-optional.

## Solution

Set `optional` flag on provides endpoints to indicate correct optionality.
