### PR TITLE
Adds fix to update Services if `loadbalancer-extra-annotations` config option is set

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -184,16 +184,22 @@ class KubernetesRouterCharm(abstract_charm.MySQLRouterCharm):
         service = self._get_service()
         service_exists = service is not None
         service_type = service_exists and _ServiceType(service.spec.type)
-        if service_exists and service_type == desired_service_type:
-            return
-
-        pod0 = self._get_pod(f"{self.app.name}/0")
-
+        service_annotations = {}
+        if service_exists:
+            service_annotations = service.metadata.annotations or {}
         annotations = (
             json.loads(self.config.get("loadbalancer-extra-annotations", "{}"))
             if desired_service_type == _ServiceType.LOAD_BALANCER
             else {}
         )
+        if (
+            service_exists
+            and service_type == desired_service_type
+            and service_annotations == annotations
+        ):
+            return
+
+        pod0 = self._get_pod(f"{self.app.name}/0")
 
         desired_service = lightkube.resources.core_v1.Service(
             metadata=lightkube.models.meta_v1.ObjectMeta(


### PR DESCRIPTION
## Issue
[450](https://github.com/canonical/mysql-router-k8s-operator/issues/450) Configuring `loadbalancer-extra-annotations` doesn't update the Kubernetes Service

## Solution

Updates the check for recreating the LoadBalancer service to verify if the current annotations match the value set inside `loadbalancer-extra-annotations` config option. If they don't match, it will update the service inside K8s